### PR TITLE
Add Next.js 13.3+ support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = {
     'import/no-unresolved': 'off',
     'import/prefer-default-export': 'off',
     'lines-between-class-members': 'off',
+    'object-curly-newline': 'off',
     'no-nested-ternary': 'off',
     'no-plusplus': 'off',
     'no-unused-vars': 'off',

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     }

--- a/src/core/pantheon-client.ts
+++ b/src/core/pantheon-client.ts
@@ -1,9 +1,6 @@
-import {
-  ApolloClient,
-  InMemoryCache,
-  NormalizedCacheObject,
-} from '@apollo/client';
+import { NormalizedCacheObject } from '@apollo/client';
 
+import { ApolloClient, InMemoryCache } from '../lib/apollo-client';
 import { DefaultLogger, Logger, NoopLogger } from '../utils/logger';
 
 interface PantheonClientConfig {

--- a/src/core/pantheon-context.tsx
+++ b/src/core/pantheon-context.tsx
@@ -1,5 +1,6 @@
-import { ApolloProvider } from '@apollo/client';
 import React, { PropsWithChildren } from 'react';
+
+import { ApolloProvider } from '../lib/apollo-client';
 
 import { PantheonClient } from './pantheon-client';
 

--- a/src/hooks/use-article.ts
+++ b/src/hooks/use-article.ts
@@ -1,7 +1,7 @@
-import { gql, useQuery } from '@apollo/client';
 import { useEffect, useRef } from 'react';
 
 import { usePantheonClient } from '../core/pantheon-context';
+import { gql, useQuery } from '../lib/apollo-client';
 import { Article } from '../types';
 
 const GET_ARTICLE_QUERY = gql`

--- a/src/hooks/use-articles.ts
+++ b/src/hooks/use-articles.ts
@@ -1,5 +1,4 @@
-import { gql, useQuery } from '@apollo/client';
-
+import { gql, useQuery } from '../lib/apollo-client';
 import { Article } from '../types';
 
 const LIST_ARTICLES_QUERY = gql`

--- a/src/lib/apollo-client/index.ts
+++ b/src/lib/apollo-client/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Re-exporting required Apollo modules to avoid
+ * SyntaxError: Named export 'ApolloClient' not found. The requested module '@apollo/client' is
+ * a CommonJS module, which may not support all module.exports as named exports.
+ * Issue tracking: https://github.com/vercel/next.js/issues/39375
+ */
+
+import { InMemoryCache } from '@apollo/client/cache/inmemory/inMemoryCache.js';
+import { ApolloClient } from '@apollo/client/core/ApolloClient.js';
+import { ApolloProvider } from '@apollo/client/react/context/ApolloProvider.js';
+import { useQuery } from '@apollo/client/react/hooks/useQuery.js';
+import gql from 'graphql-tag';
+
+export { useQuery, gql, InMemoryCache, ApolloClient, ApolloProvider };


### PR DESCRIPTION
Mainly just re-exporting Apollo members so module resolution isn't left to the Node resolver

Reference issue: https://github.com/vercel/next.js/issues/39375 