### PR TITLE
Handled relative/absolute path for project_directory_name param

### DIFF
--- a/pcc/cli.js
+++ b/pcc/cli.js
@@ -76,8 +76,9 @@ const init = async (dirName, template) => {
     { recursive: true },
   );
   chdir(dirName);
+  const appName = path.parse(dirName).base;
   const packageJson = JSON.parse(readFileSync('./package.json'));
-  packageJson.name = dirName;
+  packageJson.name = appName;
   writeFileSync('./package.json', JSON.stringify(packageJson, null, 2));
 
   // Commiting changes to Git


### PR DESCRIPTION
It was failing because it assigns the exact directory name to package name.
Updated to extract base name for the package name.