### PR TITLE
Fixes error if no tags are passed from articles

### DIFF
--- a/nextjs-starter/components/tags.jsx
+++ b/nextjs-starter/components/tags.jsx
@@ -1,7 +1,7 @@
 export const Tags = ({ tags }) => {
   return (
     <p className="mt-2 text-sm leading-[1.25rem] text-theme-bg-black">
-      {tags !==null && tags.length ? (
+      {tags?.length ? (
         <>
           Tags:&nbsp;
           {tags.map((x, i) => (

--- a/nextjs-starter/components/tags.jsx
+++ b/nextjs-starter/components/tags.jsx
@@ -1,7 +1,7 @@
 export const Tags = ({ tags }) => {
   return (
     <p className="mt-2 text-sm leading-[1.25rem] text-theme-bg-black">
-      {tags.length ? (
+      {tags !==null && tags.length ? (
         <>
           Tags:&nbsp;
           {tags.map((x, i) => (


### PR DESCRIPTION
Quick fix incase no tags are present in the article to allow the page to still render.