### PR TITLE
[PCC 440] Add webhook configuration

### DIFF
--- a/packages/cli/src/cli/commands/sites.ts
+++ b/packages/cli/src/cli/commands/sites.ts
@@ -16,20 +16,6 @@ export const createSite = errorHandler<string>(async (url: string) => {
   }
 });
 
-export const updateSite = errorHandler<{
-  id: string;
-  url: string;
-}>(async ({ id, url }: { id: string; url: string }) => {
-  const spinner = ora("Updating site...").start();
-  try {
-    await AddOnApiHelper.updateSite(id, url);
-    spinner.succeed(`Successfully updated the site for given ID.`);
-  } catch (e) {
-    spinner.fail();
-    throw e;
-  }
-});
-
 export const listSites = errorHandler<void>(async () => {
   const spinner = ora("Fetching list of existing sites...").start();
   try {
@@ -57,3 +43,51 @@ export const listSites = errorHandler<void>(async () => {
     throw e;
   }
 });
+
+export const updateSiteConfig = errorHandler(
+  async ({
+    id,
+    ...configurableProperties
+  }: {
+    id: string;
+  } & Partial<
+    Record<(typeof configurableSiteProperties)[number]["id"], string>
+  >) => {
+    const spinner = ora("Updating site...").start();
+
+    try {
+      await AddOnApiHelper.updateSiteConfig(id, configurableProperties);
+      spinner.succeed(`Successfully updated the site.`);
+    } catch (e) {
+      spinner.fail();
+      throw e;
+    }
+  },
+);
+
+export const configurableSiteProperties = [
+  {
+    id: "url",
+    command: {
+      name: "url <url>",
+      description: "Set url for a given site",
+      type: "string",
+    },
+  },
+  {
+    id: "webhookUrl",
+    command: {
+      name: "webhook-url <webhookUrl>",
+      description: "Set a webhook url for a given site",
+      type: "string",
+    },
+  },
+  {
+    id: "webhookSecret",
+    command: {
+      name: "webhook-secret <webhookSecret>",
+      description: "Set a webhook secret for a given site",
+      type: "string",
+    },
+  },
+] as const;

--- a/packages/cli/src/lib/addonApiHelper.ts
+++ b/packages/cli/src/lib/addonApiHelper.ts
@@ -113,6 +113,42 @@ class AddOnApiHelper {
       },
     );
   }
+
+  static async updateSiteConfig(
+    id: string,
+    {
+      url,
+      webhookUrl,
+      webhookSecret,
+    }: {
+      url?: string;
+      webhookUrl?: string;
+      webhookSecret?: string;
+    },
+  ): Promise<void> {
+    const authDetails = await getLocalAuthDetails();
+    if (!authDetails) throw new UserNotLoggedIn();
+
+    const configuredWebhook = webhookUrl || webhookSecret;
+
+    await axios.patch(
+      `${SITE_ENDPOINT}/${id}`,
+      {
+        ...(url && { url: url }),
+        ...(configuredWebhook && {
+          webhookConfig: {
+            ...(webhookUrl && { webhookUrl: webhookUrl }),
+            ...(webhookSecret && { webhookSecret: webhookUrl }),
+          },
+        }),
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${authDetails.id_token}`,
+        },
+      },
+    );
+  }
 }
 
 export default AddOnApiHelper;


### PR DESCRIPTION
Adds a new CLI command `pcc site configure` that allows for the configuring of a site's URL, Webhook URL and Webhook Secret. 