### PR TITLE
Render titles as header elements on page

### DIFF
--- a/packages/react-sdk/src/components/ArticleRenderer/index.tsx
+++ b/packages/react-sdk/src/components/ArticleRenderer/index.tsx
@@ -87,7 +87,7 @@ const ArticleRenderer = ({
       smartComponentMap={smartComponentMap}
     />
   ) : (
-    <span>{article?.title}</span>
+    <h1>{article?.title}</h1>
   );
 
   return (


### PR DESCRIPTION
# Overview
When a custom `renderTitle` function was not provided the React SDK would render titles on the page in <span> elements

# Changes
- Titles are rendered by default as H1's