### PR TITLE
Default to V2 tree content if contentType is not set

### DIFF
--- a/packages/core/src/helpers/articles.ts
+++ b/packages/core/src/helpers/articles.ts
@@ -117,12 +117,6 @@ export async function getArticleBySlugOrId(
   slugOrId: number | string,
   args?: ArticleQueryArgs,
 ) {
-  console.log(
-    "getArticleBySlugOrId",
-    slugOrId,
-    args?.contentType,
-    args?.publishingLevel,
-  );
   // First attempt to retrieve by slug, and fallback to by id if the matching slug
   // couldn't be found.
   try {

--- a/packages/core/src/helpers/articles.ts
+++ b/packages/core/src/helpers/articles.ts
@@ -117,6 +117,12 @@ export async function getArticleBySlugOrId(
   slugOrId: number | string,
   args?: ArticleQueryArgs,
 ) {
+  console.log(
+    "getArticleBySlugOrId",
+    slugOrId,
+    args?.contentType,
+    args?.publishingLevel,
+  );
   // First attempt to retrieve by slug, and fallback to by id if the matching slug
   // couldn't be found.
   try {
@@ -155,6 +161,7 @@ export async function getArticleBySlugOrId(
 
 function buildContentType(contentType?: keyof typeof ContentType) {
   if (
+    !contentType ||
     contentType === ContentType.TREE_PANTHEON_V2 ||
     contentType === ContentType.TREE_PANTHEON
   ) {


### PR DESCRIPTION
# Overview
Makes newer versions of the SDKs return V2 tree content if contentType is not provided instead of relying on the GQL resolver's defaults.