### PR TITLE
[PCC 588] Automate SDK publishing

### DIFF
--- a/.changeset/quiet-emus-live.md
+++ b/.changeset/quiet-emus-live.md
@@ -1,0 +1,7 @@
+---
+"@pantheon-systems/pcc-sdk-core": patch
+"@pantheon-systems/pcc-react-sdk": patch
+"@pantheon-systems/pcc-vue-sdk": patch
+---
+
+Add new Pantheon Tree format version support

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -1,0 +1,41 @@
+name: Release Canary Packages
+
+on:
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+# https://github.com/changesets/action/issues/295
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  packages: write
+
+jobs:
+  release-canary:
+    name: Canary Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8.6.11
+      - name: Setup nodejs
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "pnpm"
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Create Release Pull Request
+        uses: changesets/action@v1
+        with:
+          publish: pnpm release:canary
+          commit: "chore(release): create canary release"
+          title: "Canary Package Release"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release Stable Packages
+
+on:
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+# https://github.com/changesets/action/issues/295
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  packages: write
+
+jobs:
+  release:
+    name: Stable Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8.6.11
+      - name: Setup nodejs
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "pnpm"
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Create Release Pull Request
+        uses: changesets/action@v1
+        with:
+          publish: pnpm release
+          createGithubReleases: true
+          commit: "chore(release): create stable release"
+          title: "Stable Package Release"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -49,3 +49,37 @@ allow you to quickly get up and running with Pantheon Content Cloud.
    ```sh
    node packages/cli/dist/index.js sites list
    ```
+
+## Contributing: Versions and Releases
+
+### Generating a Changeset
+
+To generate a new changeset, run `pnpm changeset` in the root of the repository.
+The generated Markdown files in the `.changeset` directory should be committed
+to the repository.
+
+### Publishing New Versions
+
+Version numbers are automatically semantically bumped by the `changeset` GitHub
+Action.
+
+### Releases
+
+#### Stable Releases
+
+To publish a new stable release, trigger the `release.yml` GitHub Action. A pull
+request will be created with the changeset and the version bump. Once the pull
+request is merged, the `release.yml` GitHub Action will publish the new version.
+
+The published version will be tagged with the version number and installable
+with the tag `latest`.
+
+#### Canary Releases
+
+To publish a new canary release, trigger the `release-canary.yml` GitHub Action.
+A pull request will be created with the changeset and the version bump. Once the
+pull request is merged, the `release-canary.yml` GitHub Action will publish the
+new version.
+
+The published version will be tagged with the version number and installable
+with the tag `canary`.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "build:starters": "turbo run build --filter=./starters/*",
     "lint:starters": "turbo run lint --filter=./starters/*",
     "ci:publish": "changeset publish",
-    "publish:packages": "pnpm build && pnpm publish --filter \"./packages/**\""
+    "publish:packages": "pnpm build && pnpm publish --filter \"./packages/**\"",
+    "release": "pnpm build && changeset publish",
+    "release:canary": "pnpm build && changeset publish --tag canary"
   },
   "dependencies": {
     "@changesets/cli": "^2.26.2",


### PR DESCRIPTION
# Overview
Adds Github Action workflows to manage version bumps and NPM publishing of packages in the monorepo.