### PR TITLE
Disable apollo query caching

### DIFF
--- a/packages/core/src/core/pantheon-client.ts
+++ b/packages/core/src/core/pantheon-client.ts
@@ -138,6 +138,14 @@ export class PantheonClient {
     this.apolloClient = new ApolloClient({
       link: splitLink,
       cache: new InMemoryCache(),
+      defaultOptions: {
+        query: {
+          fetchPolicy: "no-cache",
+        },
+        watchQuery: {
+          fetchPolicy: "no-cache",
+        },
+      },
     });
 
     if (this.debug) {


### PR DESCRIPTION
# Overview
Disables Apollo's default caching behaviour which results in stale data sometimes. [[Ref](https://www.apollographql.com/docs/react/caching/overview)]