### PR TITLE
Set default formatter for .vue files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[vue]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}


### PR DESCRIPTION
Adds a VSCode config file to use Prettier over Volar (Vue's default language tool) when installed for formatting. Volar's output conflicts with the set repo-wide lint rules.