### PR TITLE
[PCC 674] Support for disabling article hooks

### DIFF
--- a/packages/core/src/core/pantheon-client.ts
+++ b/packages/core/src/core/pantheon-client.ts
@@ -10,25 +10,9 @@ import {
 } from "../lib/apollo-client";
 import { DefaultLogger, Logger, NoopLogger } from "../lib/logger";
 
-export interface PantheonClientConfig {
-  /**
-   * API Key for your PCC Workspace
-   * @example
-   * // If your API Key is ABC-DEF
-   * const pantheonClient = new PantheonClient({
-   *   siteId: '12345',
-   *   apiKey: 'ABC-DEF',
-   * });
-   */
-  apiKey: string;
-
+export type PantheonClientConfig = {
   debug?: boolean;
-
-  /**
-   * NOT FOR EXTERNAL USE.
-   */
   pccHost?: string;
-
   /**
    * ID of the site you want to query
    * @example
@@ -39,7 +23,16 @@ export interface PantheonClientConfig {
    * });
    */
   siteId: string;
-
+  /**
+   * API Key for your PCC Workspace
+   * @example
+   * // If your API Key is ABC-DEF
+   * const pantheonClient = new PantheonClient({
+   *   siteId: '12345',
+   *   apiKey: 'ABC-DEF',
+   * });
+   */
+  apiKey?: string;
   /**
    * Optional parameter to provide a PCC Grant in place of an API Key.
    * Useful for preventing preview content from being viewed publicly.
@@ -53,7 +46,7 @@ export interface PantheonClientConfig {
    * });
    */
   pccGrant?: string;
-}
+} & ({ apiKey: string } | { pccGrant: string });
 
 export class PantheonClient {
   public host: string;

--- a/packages/core/src/helpers/articles.ts
+++ b/packages/core/src/helpers/articles.ts
@@ -73,11 +73,11 @@ export async function getArticles(
 
   const articles = await client.apolloClient.query({
     query: LIST_ARTICLES_QUERY,
-    variables: Object.assign(
-      {},
-      { contentType, ...rest },
-      convertSearchParamsToGQL(searchParams),
-    ),
+    variables: {
+      ...rest,
+      ...convertSearchParamsToGQL(searchParams),
+      contentType,
+    },
   });
 
   return articles.data.articles as ArticleWithoutContent[];

--- a/packages/react-sdk/src/hooks/use-articles.ts
+++ b/packages/react-sdk/src/hooks/use-articles.ts
@@ -1,3 +1,4 @@
+import { type QueryHookOptions } from "@apollo/client";
 import { useQuery } from "@apollo/client/react/hooks/useQuery.js";
 import {
   ArticleQueryArgs,
@@ -16,12 +17,19 @@ type Return = ReturnType<typeof useQuery<ListArticlesResponse>> & {
   articles: ArticleWithoutContent[] | undefined;
 };
 
+type ApolloQueryOptions = Omit<
+  QueryHookOptions<ListArticlesResponse>,
+  "variables"
+>;
+
 export const useArticles = (
   args?: ArticleQueryArgs,
   searchParams?: ArticleSearchArgs,
+  apolloQueryOptions?: ApolloQueryOptions,
 ): Return => {
   const contentType = buildContentType(args?.contentType);
   const queryData = useQuery<ListArticlesResponse>(LIST_ARTICLES_QUERY, {
+    ...apolloQueryOptions,
     variables: Object.assign(
       {},
       { ...args, contentType },

--- a/packages/react-sdk/src/hooks/use-articles.ts
+++ b/packages/react-sdk/src/hooks/use-articles.ts
@@ -30,11 +30,11 @@ export const useArticles = (
   const contentType = buildContentType(args?.contentType);
   const queryData = useQuery<ListArticlesResponse>(LIST_ARTICLES_QUERY, {
     ...apolloQueryOptions,
-    variables: Object.assign(
-      {},
-      { ...args, contentType },
-      convertSearchParamsToGQL(searchParams),
-    ),
+    variables: {
+      ...args,
+      ...convertSearchParamsToGQL(searchParams),
+      contentType,
+    },
   });
 
   return {

--- a/packages/vue-sdk/src/hooks/use-articles.ts
+++ b/packages/vue-sdk/src/hooks/use-articles.ts
@@ -1,10 +1,12 @@
 import {
   ArticleQueryArgs,
+  ArticleSearchArgs,
   buildContentType,
+  convertSearchParamsToGQL,
   LIST_ARTICLES_QUERY,
 } from "@pantheon-systems/pcc-sdk-core";
 import { ArticleWithoutContent } from "@pantheon-systems/pcc-sdk-core/types";
-import { useQuery } from "@vue/apollo-composable";
+import { useQuery, type UseQueryOptions } from "@vue/apollo-composable";
 
 type ListArticlesResponse = {
   articles: ArticleWithoutContent[];
@@ -14,11 +16,25 @@ type Return = ReturnType<typeof useQuery<ListArticlesResponse>> & {
   articles: ArticleWithoutContent[] | undefined;
 };
 
-export const useArticles = (args?: ArticleQueryArgs): Return => {
+type ApolloQueryOptions = UseQueryOptions;
+
+export const useArticles = (
+  args?: ArticleQueryArgs,
+  searchParams?: ArticleSearchArgs,
+  apolloQueryOptions?: ApolloQueryOptions,
+): Return => {
   const contentType = buildContentType(args?.contentType);
-  const queryData = useQuery<ListArticlesResponse>(LIST_ARTICLES_QUERY, {
-    variables: { ...args, contentType },
-  });
+  const queryData = useQuery<ListArticlesResponse>(
+    LIST_ARTICLES_QUERY,
+    {
+      variables: Object.assign(
+        {},
+        { ...args, contentType },
+        convertSearchParamsToGQL(searchParams),
+      ),
+    },
+    apolloQueryOptions ?? {},
+  );
 
   return {
     ...queryData,

--- a/packages/vue-sdk/src/hooks/use-articles.ts
+++ b/packages/vue-sdk/src/hooks/use-articles.ts
@@ -27,11 +27,11 @@ export const useArticles = (
   const queryData = useQuery<ListArticlesResponse>(
     LIST_ARTICLES_QUERY,
     {
-      variables: Object.assign(
-        {},
-        { ...args, contentType },
-        convertSearchParamsToGQL(searchParams),
-      ),
+      variables: {
+        ...args,
+        ...convertSearchParamsToGQL(searchParams),
+        contentType,
+      },
     },
     apolloQueryOptions ?? {},
   );


### PR DESCRIPTION
# Overview
Adds support for disabling useArticle hooks at runtime, removing the need to create different components for prod and preview article views. 

# Changes
- Adds support for forwarding query options from the SDKs to the Apollo Client. 
- Updated the `PantheonClientConfig` type to use a discriminated union for the `apiKey` and `pccGrant` properties. Now, you must provide at least one of these properties. This change aligns with the `PantheonClient` implementation, which already preferred the `pccGrant` over the `apiKey` when both were available. With this update, TypeScript won't throw an error if a `pccGrant` is provided without an `apiKey`
- Adds support for `searchParams` in Vue `useArticles` hook