### PR TITLE
Pin nuxt version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,7 +308,7 @@ importers:
         version: link:../core
       '@vue/apollo-composable':
         specifier: ^4.0.0-beta.7
-        version: 4.0.0-beta.7(@apollo/client@3.7.17)(graphql@16.8.1)(typescript@5.1.6)(vue@3.3.4)
+        version: 4.0.0-beta.7(@apollo/client@3.7.17)(@vue/composition-api@1.0.0-rc.1)(graphql@16.8.1)(typescript@5.1.6)(vue@3.3.4)
       '@vue/composition-api':
         specifier: '>=1.0.0-rc.1'
         version: 1.0.0-rc.1(vue@3.3.4)
@@ -326,7 +326,7 @@ importers:
         version: 8.1.0
       vue-demi:
         specifier: latest
-        version: 0.14.6(vue@3.3.4)
+        version: 0.14.6(@vue/composition-api@1.0.0-rc.1)(vue@3.3.4)
     devDependencies:
       '@types/markdown-it':
         specifier: ^13.0.2
@@ -637,7 +637,7 @@ importers:
         specifier: ^10.4.16
         version: 10.4.16(postcss@8.4.31)
       nuxt:
-        specifier: ^3.7.4
+        specifier: 3.7.4
         version: 3.7.4(eslint@8.46.0)
       postcss:
         specifier: ^8.4.31
@@ -668,7 +668,7 @@ importers:
         specifier: ^10.4.16
         version: 10.4.16(postcss@8.4.31)
       nuxt:
-        specifier: ^3.7.4
+        specifier: 3.7.4
         version: 3.7.4(eslint@8.46.0)
       postcss:
         specifier: ^8.4.31
@@ -7569,7 +7569,7 @@ packages:
       - rollup
     dev: true
 
-  /@vue/apollo-composable@4.0.0-beta.7(@apollo/client@3.7.17)(graphql@16.8.1)(typescript@5.1.6)(vue@3.3.4):
+  /@vue/apollo-composable@4.0.0-beta.7(@apollo/client@3.7.17)(@vue/composition-api@1.0.0-rc.1)(graphql@16.8.1)(typescript@5.1.6)(vue@3.3.4):
     resolution: {integrity: sha512-BCKK9xAH67e033Q715nzhGwn9PlnTACb+840qQQjSa1YFwjeiDufPpJ/GGqaLGqJgTm+wgpIljA/H+MYDFhe6g==}
     peerDependencies:
       '@apollo/client': ^3.4.13
@@ -7581,11 +7581,12 @@ packages:
         optional: true
     dependencies:
       '@apollo/client': 3.7.17(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
+      '@vue/composition-api': 1.0.0-rc.1(vue@3.3.4)
       graphql: 16.8.1
       throttle-debounce: 3.0.1
       ts-essentials: 9.3.2(typescript@5.1.6)
       vue: 3.3.4
-      vue-demi: 0.13.11(vue@3.3.4)
+      vue-demi: 0.13.11(@vue/composition-api@1.0.0-rc.1)(vue@3.3.4)
     transitivePeerDependencies:
       - typescript
     dev: false
@@ -21863,10 +21864,11 @@ packages:
       mlly: 1.4.2
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 3.2.7(@types/node@20.4.6)
+      vite: 4.4.11(@types/node@20.4.6)(sass@1.69.5)
     transitivePeerDependencies:
       - '@types/node'
       - less
+      - lightningcss
       - sass
       - stylus
       - sugarss
@@ -22142,7 +22144,7 @@ packages:
       ufo: 1.3.1
     dev: true
 
-  /vue-demi@0.13.11(vue@3.3.4):
+  /vue-demi@0.13.11(@vue/composition-api@1.0.0-rc.1)(vue@3.3.4):
     resolution: {integrity: sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==}
     engines: {node: '>=12'}
     hasBin: true
@@ -22154,10 +22156,11 @@ packages:
       '@vue/composition-api':
         optional: true
     dependencies:
+      '@vue/composition-api': 1.0.0-rc.1(vue@3.3.4)
       vue: 3.3.4
     dev: false
 
-  /vue-demi@0.14.6(vue@3.3.4):
+  /vue-demi@0.14.6(@vue/composition-api@1.0.0-rc.1)(vue@3.3.4):
     resolution: {integrity: sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==}
     engines: {node: '>=12'}
     hasBin: true
@@ -22169,6 +22172,7 @@ packages:
       '@vue/composition-api':
         optional: true
     dependencies:
+      '@vue/composition-api': 1.0.0-rc.1(vue@3.3.4)
       vue: 3.3.4
     dev: false
 

--- a/starters/vue-starter-ts/package.json
+++ b/starters/vue-starter-ts/package.json
@@ -13,7 +13,7 @@
     "@nuxt/devtools": "latest",
     "@tailwindcss/typography": "^0.5.9",
     "autoprefixer": "^10.4.16",
-    "nuxt": "^3.7.4",
+    "nuxt": "3.7.4",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.3.3",
     "vue": "^3.3.4",

--- a/starters/vue-starter/package.json
+++ b/starters/vue-starter/package.json
@@ -13,7 +13,7 @@
     "@nuxt/devtools": "latest",
     "@tailwindcss/typography": "^0.5.9",
     "autoprefixer": "^10.4.16",
-    "nuxt": "^3.7.4",
+    "nuxt": "3.7.4",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.3.3",
     "vue": "^3.3.4",


### PR DESCRIPTION
# Issue
Nuxt version 3.8 introduced breaking changes which cause our Vue starter kits to fail out of the box. 
Specifically, [`verbatimModuleSyntax` is now enabled by default](https://nuxt.com/blog/v3-8#type-import-changes). 

We could fix this one issue but since the project doesn't strictly follow semver, more breaking changes could be added breaking our examples.

# Changes
* Nuxt dependency in Vue starters is pinned to v3.7.4