### PR TITLE
Keep webhook history command alive

### DIFF
--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -25,6 +25,8 @@ const configureMiddleware = (func: () => void) => {
   return func;
 };
 
+const LONG_LIVED_COMMANDS = ["site webhooks history"];
+
 yargs(hideBin(process.argv))
   .scriptName("pcc")
   .usage("$0 <cmd>")
@@ -376,4 +378,9 @@ yargs(hideBin(process.argv))
   )
   .help(true)
   .parseAsync()
-  .then(() => process.exit());
+  .then((res) => {
+    const command = res._.join(" ");
+    if (LONG_LIVED_COMMANDS.includes(command)) return;
+
+    process.exit();
+  });


### PR DESCRIPTION
# Issue
[#88fd1af](https://github.com/pantheon-systems/pantheon-content-cloud-sdk/commit/88fd1af34f434593c9b69841783f9c00a9c750c6) updated the CLI to force exit after completion. This broke the webhook history command which started a long lived HTTP server for viewing the logs.
