### PR TITLE
Make auth expiry check local time agnostic

### DIFF
--- a/packages/cli/src/lib/addonApiHelper.ts
+++ b/packages/cli/src/lib/addonApiHelper.ts
@@ -24,6 +24,11 @@ class AddOnApiHelper {
     return resp.data as Credentials;
   }
 
+  static async getCurrentTime(): Promise<number> {
+    const resp = await axios.get(`${config.addOnApiEndpoint}/ping`);
+    return resp.data.timestamp as number;
+  }
+
   static async getIdToken(): Promise<string> {
     let authDetails = await getLocalAuthDetails();
 

--- a/packages/cli/src/lib/addonApiHelper.ts
+++ b/packages/cli/src/lib/addonApiHelper.ts
@@ -25,8 +25,13 @@ class AddOnApiHelper {
   }
 
   static async getCurrentTime(): Promise<number> {
-    const resp = await axios.get(`${config.addOnApiEndpoint}/ping`);
-    return Number(resp.data.timestamp);
+    try {
+      const resp = await axios.get(`${config.addOnApiEndpoint}/ping`);
+      return Number(resp.data.timestamp);
+    } catch {
+      // If ping fails, return current time
+      return Date.now();
+    }
   }
 
   static async getIdToken(): Promise<string> {

--- a/packages/cli/src/lib/addonApiHelper.ts
+++ b/packages/cli/src/lib/addonApiHelper.ts
@@ -26,7 +26,7 @@ class AddOnApiHelper {
 
   static async getCurrentTime(): Promise<number> {
     const resp = await axios.get(`${config.addOnApiEndpoint}/ping`);
-    return resp.data.timestamp as number;
+    return Number(resp.data.timestamp);
   }
 
   static async getIdToken(): Promise<string> {

--- a/packages/cli/src/lib/localStorage.ts
+++ b/packages/cli/src/lib/localStorage.ts
@@ -1,11 +1,9 @@
 import { readFileSync, writeFileSync } from "fs";
 import path from "path";
 import { ensureFile } from "fs-extra";
-import { Credentials, OAuth2Client } from "google-auth-library";
+import { Credentials } from "google-auth-library";
 import { PCC_ROOT_DIR } from "../constants";
 import AddOnApiHelper from "./addonApiHelper";
-
-const client = new OAuth2Client();
 
 export const AUTH_FILE_PATH = path.join(PCC_ROOT_DIR, "auth.json");
 export const getLocalAuthDetails = async (): Promise<Credentials | null> => {


### PR DESCRIPTION
# Issue
In environments where the local time was set wrongly, the local time dependent `Date.now()` check would return wrong values which would then be used in the token expiry check. This would cause the CLI to always exit with "Not logged in" errors even though the auth details are valid.  

# Changes
- UTC time sourced from the api is used in checking expiry. 

# Other Changes
- Fixes auth file path creation on Windows. 