### PR TITLE
[PCC-740] Set cookie with lax same site attribute

### DIFF
--- a/packages/core/src/core/pantheon-api.ts
+++ b/packages/core/src/core/pantheon-api.ts
@@ -95,7 +95,7 @@ export const PantheonAPI =
     if (pccGrant) {
       await res.setHeader(
         "Set-Cookie",
-        `PCC-GRANT=${pccGrant}; Path=/; SameSite=Strict`,
+        `PCC-GRANT=${pccGrant}; Path=/; SameSite=Lax`,
       );
     } else if (
       options?.getSiteId != null &&
@@ -116,7 +116,7 @@ export const PantheonAPI =
         ) {
           await res.setHeader(
             "Set-Cookie",
-            `PCC-GRANT=deleted; Path=/; SameSite=Strict; Expires=Thu, 01 Jan 1970 00:00:00 GMT`,
+            `PCC-GRANT=deleted; Path=/; SameSite=Lax; Expires=Thu, 01 Jan 1970 00:00:00 GMT`,
           );
         }
       } catch (e) {

--- a/starters/nextjs-starter-ts/pages/articles/[...uri].tsx
+++ b/starters/nextjs-starter-ts/pages/articles/[...uri].tsx
@@ -98,10 +98,7 @@ export async function getServerSideProps({
   );
 
   if (pccGrant) {
-    res.setHeader(
-      "Set-Cookie",
-      `PCC-GRANT=${pccGrant}; Path=/; SameSite=Strict`,
-    );
+    res.setHeader("Set-Cookie", `PCC-GRANT=${pccGrant}; Path=/; SameSite=Lax`);
   }
 
   if (!article) {


### PR DESCRIPTION
# Issue
`SameSite` as `Strict` allowed us to prevent the grant from being sent out on third party resource requests. This however also caused browsers to refuse to send the grant cookie when the user navigated in from a different site (in this case the add-on) breaking the preview flow.

This issue already existed but surfaced due to the changes in Playground PR 50 

# Changes
To fix this, the grant cookie is now set with `SameSite` as `Lax`. This change still prevents the grant from being sent with third party resource requests but allows the grant to be honoured when it is set from top level navigations from external sites