### PR TITLE
[PCC 733] Extend Vue renderer props

### DIFF
--- a/packages/vue-sdk/src/components/Preview/index.vue
+++ b/packages/vue-sdk/src/components/Preview/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Article } from "@pantheon-systems/pcc-sdk-core/types";
+import type { PreviewBarProps } from "../Renderer";
 import queryString from "query-string";
 import { PropType, ref, watchEffect } from "vue-demi";
 
@@ -9,9 +9,18 @@ import LivePreviewIndicator from "./LivePreviewIndicator.vue";
 import HamburgerIcon from "./assets/HamburgerIcon.vue";
 import HoverButton from "../Common/HoverButton.vue";
 import { getCookie } from "../../utils/cookies";
+import { Article } from "@pantheon-systems/pcc-sdk-core/types";
 
 const props = defineProps({
   article: Object as PropType<Article>,
+  previewBarOverride: {
+    type: Object as PropType<PreviewBarProps["previewBarOverride"]>,
+    required: false,
+  },
+  collapsedPreviewBarProps: {
+    type: Object as PropType<PreviewBarProps["collapsedPreviewBarProps"]>,
+    required: false,
+  },
 });
 
 const isLive = ref(false);
@@ -67,7 +76,15 @@ watchEffect(() => {
 </script>
 
 <template>
-  <div :class="['wrapper', isHidden && 'hidden']">
+  <div v-if="previewBarOverride">
+    <component
+      :is="previewBarOverride"
+      :article="article"
+      :isHidden="isHidden"
+    />
+  </div>
+
+  <div v-else :class="['wrapper', isHidden && 'hidden']">
     <div v-if="!isHidden" class="container">
       <a class="title-link">
         <DocsLogo />
@@ -86,7 +103,10 @@ watchEffect(() => {
       </div>
     </div>
 
-    <div :class="['controller-container', isHidden && 'active']">
+    <div
+      v-bind="isHidden ? collapsedPreviewBarProps : null"
+      :class="['controller-container', isHidden && 'active']"
+    >
       <div v-if="isHidden">
         <LivePreviewIndicator :isLive="isLive" />
         <HoverButton @click="isHidden = !isHidden">

--- a/packages/vue-sdk/src/components/Renderer/index.ts
+++ b/packages/vue-sdk/src/components/Renderer/index.ts
@@ -23,6 +23,11 @@ export type SmartComponentMap = {
   [key: string]: InstanceType<DefineComponent<any, any, any>>;
 };
 
+export type PreviewBarProps = {
+  previewBarOverride?: InstanceType<DefineComponent<any, any, any>>;
+  collapsedPreviewBarProps?: Record<string, unknown>;
+};
+
 const ArticleRenderer = defineComponent({
   name: "ArticleRenderer",
   props: {
@@ -32,6 +37,18 @@ const ArticleRenderer = defineComponent({
     },
     smartComponentMap: {
       type: Object as PropType<SmartComponentMap>,
+      required: false,
+    },
+    bodyClass: {
+      type: String,
+      required: false,
+    },
+    headerClass: {
+      type: String,
+      required: false,
+    },
+    previewBarProps: {
+      type: Object as PropType<PreviewBarProps>,
       required: false,
     },
   },
@@ -89,7 +106,7 @@ const ArticleRenderer = defineComponent({
     return h("div", {}, [
       props.article.publishingLevel === "REALTIME"
         ? h(Teleport, { to: "body" }, [
-            h(PreviewBar, { article: props.article }),
+            h(PreviewBar, { ...this.previewBarProps, article: props.article }),
           ])
         : null,
       slots.titleRenderer
@@ -99,17 +116,21 @@ const ArticleRenderer = defineComponent({
               title: titleText,
             }),
           )
-        : // @ts-expect-error Dynamic component props
-          h(renderer, {
-            element: titleElement,
-          }),
-      parsedContent.map((element) => {
-        // @ts-expect-error Dynamic component props
-        return h(renderer, {
-          element,
-          smartComponentMap: props.smartComponentMap,
-        });
-      }),
+        : h("div", { class: props.headerClass }, [
+            // @ts-expect-error Dynamic component props
+            h(renderer, {
+              element: titleElement,
+            }),
+          ]),
+      h("div", { class: props.bodyClass }, [
+        parsedContent.map((element) => {
+          // @ts-expect-error Dynamic component props
+          return h(renderer, {
+            element,
+            smartComponentMap: props.smartComponentMap,
+          });
+        }),
+      ]),
     ]);
   },
 });


### PR DESCRIPTION
# Overview
Adds new props to Vue article renderer to bring it up to feature parity with React version 