### PR TITLE
[Fix] Download template files directly in binary

### DIFF
--- a/packages/cli/src/lib/downloadTemplateDirectory.ts
+++ b/packages/cli/src/lib/downloadTemplateDirectory.ts
@@ -66,13 +66,13 @@ async function fetchFiles(directory: string, printVerbose?: boolean) {
     const { data } = await axios.get(
       `https://raw.githubusercontent.com/${owner}/${repo}/main/${path}`,
       {
-        responseType: "text",
+        responseType: "arraybuffer",
       },
     );
 
     return {
       path: path.replace(directory, ""),
-      contents: Buffer.from(data, "utf-8"),
+      contents: data,
     };
   });
 


### PR DESCRIPTION
# Issue
The CLI's init command used Axios with responseType set to 'text' to download template files. This worked for text-based code files but corrupted binary files like PNGs, as it converted binary data to UTF-8 text before writing to a file.

# Changes
Removed the to-text conversion, received binary data is now written directly to disk, preserving the integrity of all types of files.  