### PR TITLE
[Fix] Export separate CSS file in Vue SDK

### DIFF
--- a/packages/vue-sdk/README.md
+++ b/packages/vue-sdk/README.md
@@ -47,6 +47,9 @@ style and render in your app.
 import { useArticle } from "@pantheon-systems/pcc-vue-sdk";
 import { ArticleRenderer } from "@pantheon-systems/pcc-vue-sdk/components";
 
+// Import the default styles
+import "@pantheon-systems/pcc-vue-sdk/components/style.css";
+
 const { id } = defineProps({
   id: {
     type: String,
@@ -81,6 +84,9 @@ Fetch an article by ID.
 <script setup>
 import { useArticle } from "@pantheon-systems/pcc-vue-sdk";
 import { ArticleRenderer } from "@pantheon-systems/pcc-vue-sdk/components";
+
+// Import the default styles
+import "@pantheon-systems/pcc-vue-sdk/components/style.css";
 
 const { id } = defineProps({
   id: {

--- a/packages/vue-sdk/package.json
+++ b/packages/vue-sdk/package.json
@@ -17,6 +17,7 @@
       "require": "./dist/components/index.js",
       "import": "./dist/components/index.mjs"
     },
+    "./components/style.css": "./dist/components/index.css",
     "./nuxt": {
       "types": "./dist/platforms/nuxt.d.ts",
       "require": "./dist/platforms/nuxt.cjs",

--- a/packages/vue-sdk/src/components/Preview/LivePreviewIndicator.vue
+++ b/packages/vue-sdk/src/components/Preview/LivePreviewIndicator.vue
@@ -3,7 +3,6 @@ import IconDot from "./assets/IconDot.vue";
 import IconInfo from "./assets/IconInfo.vue";
 
 import { Tooltip } from "floating-vue";
-import "floating-vue/dist/style.css";
 
 defineProps({
   isLive: Boolean,
@@ -40,6 +39,8 @@ defineProps({
 </template>
 
 <style scoped lang="scss">
+@import "floating-vue/dist/style.css";
+
 .lpi-container {
   border: 1px solid #cfcfd3;
   font-weight: 600;

--- a/packages/vue-sdk/tsup.config.ts
+++ b/packages/vue-sdk/tsup.config.ts
@@ -1,49 +1,6 @@
-import path from "path";
 import GlobalsPlugin from "esbuild-plugin-globals";
-import { defineConfig, Options } from "tsup";
+import { defineConfig } from "tsup";
 import VuePlugin from "unplugin-vue/esbuild";
-
-const injectCSSImportPlugin = {
-  name: "string-replacement",
-  setup(build) {
-    build.onEnd((result) => {
-      const outputs = result.outputFiles;
-
-      const outputCSSFiles = outputs?.filter((output) =>
-        output.path.endsWith(".css"),
-      );
-
-      if (!outputCSSFiles || outputCSSFiles.length < 1) return;
-
-      // Find the sibling JS file. It will have the same path but instead of
-      // `.css` it will be either `.cjs` or `.mjs`.
-      const outputJSFiles = outputs?.filter(
-        (output) =>
-          output.path === outputCSSFiles[0].path.replace(".css", ".cjs") ||
-          output.path === outputCSSFiles[0].path.replace(".css", ".mjs"),
-      );
-
-      if (!outputJSFiles || outputJSFiles.length < 1) return;
-
-      const cssFile = outputCSSFiles[0];
-      const jsFile = outputJSFiles[0];
-
-      const relativePath = path.relative(
-        path.dirname(jsFile.path),
-        cssFile.path,
-      );
-
-      const isCJS = jsFile.path.endsWith(".cjs");
-      const importStatement = isCJS
-        ? `require("./${relativePath}");`
-        : `import "./${relativePath}";`;
-
-      // Convert the import statement to a byte array and prepend it to the JS file
-      const importStatementArray = Buffer.from(`${importStatement}\n`);
-      jsFile.contents = Buffer.concat([importStatementArray, jsFile.contents]);
-    });
-  },
-} satisfies NonNullable<Options["esbuildPlugins"]>[number];
 
 export default defineConfig({
   treeshake: true,
@@ -80,6 +37,5 @@ export default defineConfig({
         preprocessLang: "scss",
       },
     }),
-    injectCSSImportPlugin,
   ],
 });

--- a/starters/vue-starter-ts/components/article/ArticleView.vue
+++ b/starters/vue-starter-ts/components/article/ArticleView.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { ArticleRenderer } from '@pantheon-systems/pcc-vue-sdk/components'
+import '@pantheon-systems/pcc-vue-sdk/components/style.css'
+
 import LeadCapture from '../smart-components/LeadCapture.vue'
 import type { Article } from '@pantheon-systems/pcc-vue-sdk'
 import type { PropType } from 'vue';

--- a/starters/vue-starter-ts/nuxt.config.ts
+++ b/starters/vue-starter-ts/nuxt.config.ts
@@ -2,16 +2,6 @@
 export default defineNuxtConfig({
   devtools: { enabled: true },
   css: ["~/assets/css/main.css"],
-  imports: {
-    transform: {
-      // Fix for monorepo support
-      // You can remove this if you cloned this starter or used the pcc create command
-      exclude: [/packages\/vue-sdk/],
-    },
-  },
-  build: {
-    transpile: [/@pantheon-systems\/pcc-vue-sdk/],
-  },
   postcss: {
     plugins: {
       tailwindcss: {},

--- a/starters/vue-starter/components/article/ArticleView.vue
+++ b/starters/vue-starter/components/article/ArticleView.vue
@@ -1,5 +1,7 @@
 <script setup>
 import { ArticleRenderer } from '@pantheon-systems/pcc-vue-sdk/components'
+import '@pantheon-systems/pcc-vue-sdk/components/style.css'
+
 import LeadCapture from '~/components/smart-components/LeadCapture.vue'
 
 defineProps({

--- a/starters/vue-starter/nuxt.config.js
+++ b/starters/vue-starter/nuxt.config.js
@@ -2,21 +2,11 @@
 export default defineNuxtConfig({
   devtools: { enabled: true },
   css: ["~/assets/css/main.css"],
-  imports: {
-    transform: {
-      // Fix for monorepo support
-      // You can remove this if you cloned this starter or used the pcc create command
-      exclude: [/packages\/vue-sdk/],
-    },
-  },
   postcss: {
     plugins: {
       tailwindcss: {},
       autoprefixer: {},
     },
-  },
-  build: {
-    transpile: [/@pantheon-systems\/pcc-vue-sdk/],
   },
   runtimeConfig: {
     public: {


### PR DESCRIPTION
# Issue
In an attempt to make it easier to use the Vue SDK, we inlined the import of css files used in the SDK so an extra import was not required.

This kind of worked, but has consistently caused problems on Nuxt: 
1. Having to add transpilation of the SDK to support the css import in JS
2. Having to add the import transform config option, which was only needed in the monorepo in addition
3. Most recently, the package not working when used with NPM because NPM's nested dependency node_modules structure meant the transpiled package could not resolve its dependencies

This PR removes the CSS inlining in favor of exporting a CSS file to be imported. This allows the package to be used in Vue environments without a build step (browser usage) as well as without framework specific workarounds. Requiring the CSS import is also consistent with what existing Vue component libraries ask you to do and so is not an unreasonable change, ref: [Quasar](https://quasar.dev/start/vite-plugin#using-quasar), [FloatingVue](https://floating-vue.starpad.dev/guide/installation), [PrimeVue](https://primevue.org/installation/#styled)

# Changes
- Adds a `components/style.css` export to the Vue SDK. This file contains the styles necessary to correctly render the exported components and as such must be imported when a Vue component the SDK provides is used. 
- Removes custom esbuild plugin that inlined the css imports
- Removes nuxt.config options added to the starters to support inlined css that are no longer necessary
- Updates package documentation with instructions on using the exported css file. 