### PR TITLE
[PCC 792] Add `file` smart component field type

### DIFF
--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -86,8 +86,8 @@ export const SmartComponentMapZod = z.record(
     fields: z.record(
       z.string(),
       z.object({
-        displayName: z.string().nullable().optional(),
-        required: z.boolean().nullable().optional(),
+        displayName: z.string(),
+        required: z.boolean(),
         type: z.enum(["string", "number", "boolean", "date", "file"]),
       }),
     ),

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -88,7 +88,7 @@ export const SmartComponentMapZod = z.record(
       z.object({
         displayName: z.string().nullable().optional(),
         required: z.boolean().nullable().optional(),
-        type: z.string().nullable(),
+        type: z.enum(["string", "number", "boolean", "date", "file"]),
       }),
     ),
   }),

--- a/starters/nextjs-starter-ts/components/smart-components/index.ts
+++ b/starters/nextjs-starter-ts/components/smart-components/index.ts
@@ -1,3 +1,4 @@
+import { SmartComponentMap } from "@pantheon-systems/pcc-react-sdk";
 import LeadCapture from "./lead-capture";
 
 export const serverSmartComponentMap = {
@@ -17,7 +18,7 @@ export const serverSmartComponentMap = {
       },
     },
   },
-};
+} satisfies SmartComponentMap;
 
 export const clientSmartComponentMap = {
   LEAD_CAPTURE: {

--- a/starters/vue-starter-ts/pages/articles/[id].vue
+++ b/starters/vue-starter-ts/pages/articles/[id].vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import ArticlePreview from '../../components/article/ArticlePreview.vue';
 import ArticleView from '../../components/article/ArticleView.vue';
-import type { PantheonClientConfig } from '@pantheon-systems/pcc-vue-sdk';
+import { type Article, type PantheonClientConfig } from '@pantheon-systems/pcc-vue-sdk';
 
 const route = useRoute()
 const config = useRuntimeConfig()
@@ -18,7 +18,7 @@ const pantheonConfig = {
 
 const articleId = route.params.id
 
-const { data: article, error } = await useFetch(`/api/articles/${articleId}`, {
+const { data: article, error } = await useFetch<Article>(`/api/articles/${articleId}`, {
   query: {
     publishingLevel
   }

--- a/starters/vue-starter-ts/server/lib/pantheon.ts
+++ b/starters/vue-starter-ts/server/lib/pantheon.ts
@@ -1,6 +1,7 @@
 import {
   PantheonClient,
   PantheonClientConfig,
+  type SmartComponentMap,
 } from "@pantheon-systems/pcc-vue-sdk";
 
 const { PCC_SITE_ID, PCC_API_KEY } = process.env;
@@ -38,4 +39,4 @@ export const smartComponentMap = {
       },
     },
   },
-};
+} satisfies SmartComponentMap;


### PR DESCRIPTION
# Changes
- Adds new `file` smart component field type 
- Makes `required` and `displayName` fields required, bringing the smart component type in the SDK to parity with the type expected serverside. 
- Adds some type assertions in Typescript starters, fixing type errors.