### PR TITLE
Remove auth token specification in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,3 @@
 shamefully-hoist=true
 save-workspace-protocol=false
 prefer-workspace-packages=true
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/packages/cli/.npmrc
+++ b/packages/cli/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/packages/react-sdk/.npmrc
+++ b/packages/react-sdk/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
# Motivation

When the NPM_TOKEN environment variable used in the `.npmrc` config file was not set, PNPM would issue an easy to miss warning and continue other ops without respecting the config rules set in the npmrc, leading to hard to debug issues with workspace package symlinking.

# Changes
- Removes authToken config line in `npmrc`. Our publish workflow does not use this and so should be fine. 