### PR TITLE
Improve component definition readability

### DIFF
--- a/packages/react-sample-library/src/components/Avatar/index.tsx
+++ b/packages/react-sample-library/src/components/Avatar/index.tsx
@@ -30,7 +30,7 @@ export const smartComponentDefinition = {
     image: {
       type: "file",
       required: false,
-      displayName: "Image",
+      displayName: "Image URL",
     },
     /**
      * Size of the avatar

--- a/packages/react-sample-library/src/components/Badge/Badge.stories.ts
+++ b/packages/react-sample-library/src/components/Badge/Badge.stories.ts
@@ -14,7 +14,6 @@ export default meta;
 export const Default: Story = {
   args: {
     label: "Info",
-    hasStatusType: true,
     statusType: "info",
   },
 };

--- a/packages/react-sample-library/src/components/Badge/index.tsx
+++ b/packages/react-sample-library/src/components/Badge/index.tsx
@@ -7,14 +7,13 @@ import { type InferSmartComponentProps } from "@pantheon-systems/pcc-sdk-core";
 export const reactComponent = ({
   statusType,
   label,
-  hasStatusType,
   className,
 }: InferSmartComponentProps<typeof smartComponentDefinition>) => {
   return (
     <BaseBadge
-      statusType={statusType}
       label={label}
-      hasStatusType={hasStatusType}
+      statusType={statusType}
+      hasStatusType={statusType != null}
       className={className}
     />
   );
@@ -25,12 +24,20 @@ export const smartComponentDefinition = {
   iconUrl: null,
   fields: {
     /**
+     * Text to display in the badge
+     */
+    label: {
+      displayName: "Label",
+      type: "string",
+      required: true,
+    },
+    /**
      * Status type for badge. Only renders if `hasStatusType` is true.
      */
     statusType: {
       displayName: "Status Type",
       type: "enum",
-      required: true,
+      required: false,
       options: [
         {
           label: "Status",
@@ -61,22 +68,6 @@ export const smartComponentDefinition = {
           value: "neutral",
         },
       ],
-    },
-    /**
-     * Text to display in the badge
-     */
-    label: {
-      displayName: "Label",
-      type: "string",
-      required: true,
-    },
-    /**
-     * Should the badge be associated with a certain status type
-     */
-    hasStatusType: {
-      displayName: "Has status type",
-      type: "boolean",
-      required: false,
     },
     className: {
       displayName: "Additional CSS classes",

--- a/packages/react-sample-library/src/components/BannerNotification/index.tsx
+++ b/packages/react-sample-library/src/components/BannerNotification/index.tsx
@@ -23,6 +23,14 @@ export const smartComponentDefinition = {
   iconUrl: null,
   fields: {
     /**
+     * The message to display
+     */
+    message: {
+      displayName: "Message",
+      type: "string",
+      required: true,
+    },
+    /**
      * Banner style and Icon types
      */
     type: {
@@ -43,14 +51,6 @@ export const smartComponentDefinition = {
           value: "info",
         },
       ],
-    },
-    /**
-     * The message to display
-     */
-    message: {
-      displayName: "Message",
-      type: "string",
-      required: true,
     },
     className: {
       displayName: "Additional CSS classes",

--- a/packages/react-sample-library/src/components/Blockquote/index.tsx
+++ b/packages/react-sample-library/src/components/Blockquote/index.tsx
@@ -27,25 +27,6 @@ export const smartComponentDefinition = {
   iconUrl: null,
   fields: {
     /**
-     * Set type to full width or inline blockquote
-     * @default full-width
-     */
-    type: {
-      displayName: "Type",
-      type: "enum",
-      required: false,
-      options: [
-        {
-          label: "Full width",
-          value: "full-width",
-        },
-        {
-          label: "Inline",
-          value: "inline",
-        },
-      ],
-    },
-    /**
      * Quote text
      */
     quote: {
@@ -68,6 +49,25 @@ export const smartComponentDefinition = {
       displayName: "Source",
       type: "string",
       required: true,
+    },
+    /**
+     * Set type to full width or inline blockquote
+     * @default full-width
+     */
+    type: {
+      displayName: "Type",
+      type: "enum",
+      required: false,
+      options: [
+        {
+          label: "Full width",
+          value: "full-width",
+        },
+        {
+          label: "Inline",
+          value: "inline",
+        },
+      ],
     },
     className: {
       displayName: "Additional CSS classes",

--- a/packages/react-sample-library/src/components/CTALink/index.tsx
+++ b/packages/react-sample-library/src/components/CTALink/index.tsx
@@ -24,6 +24,22 @@ export const smartComponentDefinition = {
   iconUrl: null,
   fields: {
     /**
+     * Link text
+     */
+    linkText: {
+      displayName: "Link text",
+      type: "string",
+      required: true,
+    },
+    /**
+     * Link location
+     */
+    href: {
+      displayName: "Link URL",
+      type: "string",
+      required: true,
+    },
+    /**
      * Size of the CTA Link
      * @default md
      */
@@ -41,22 +57,6 @@ export const smartComponentDefinition = {
           value: "md",
         },
       ],
-    },
-    /**
-     * Link location
-     */
-    href: {
-      displayName: "Href",
-      type: "string",
-      required: true,
-    },
-    /**
-     * Link text
-     */
-    linkText: {
-      displayName: "Link text",
-      type: "string",
-      required: true,
     },
     className: {
       displayName: "Additional CSS classes",

--- a/packages/react-sample-library/src/components/Card/index.tsx
+++ b/packages/react-sample-library/src/components/Card/index.tsx
@@ -77,7 +77,7 @@ export const smartComponentDefinition = {
      * Url for primary link
      */
     primaryLinkUrl: {
-      displayName: "Primary Link Url",
+      displayName: "Primary Link URL",
       type: "string",
       required: true,
     },
@@ -152,7 +152,7 @@ export const smartComponentDefinition = {
      * Url for secondary link
      */
     secondaryLinkUrl: {
-      displayName: "Secondary Link Url",
+      displayName: "Secondary Link URL",
       type: "string",
       required: false,
     },

--- a/packages/react-sample-library/src/components/InlineBannerNotification/index.tsx
+++ b/packages/react-sample-library/src/components/InlineBannerNotification/index.tsx
@@ -25,6 +25,14 @@ export const smartComponentDefinition = {
   iconUrl: null,
   fields: {
     /**
+     * Text for the title section
+     */
+    title: {
+      displayName: "Title",
+      type: "string",
+      required: true,
+    },
+    /**
      * Banner style and Icon types
      */
     type: {
@@ -51,18 +59,10 @@ export const smartComponentDefinition = {
       ],
     },
     /**
-     * Text for the title section
-     */
-    title: {
-      displayName: "Title",
-      type: "string",
-      required: true,
-    },
-    /**
      * Text for the message section
      */
     text: {
-      displayName: "Text",
+      displayName: "Message Text",
       type: "string",
       required: false,
     },

--- a/packages/react-sample-library/src/components/SectionBannerNotification/index.tsx
+++ b/packages/react-sample-library/src/components/SectionBannerNotification/index.tsx
@@ -29,6 +29,22 @@ export const smartComponentDefinition = {
   iconUrl: null,
   fields: {
     /**
+     * Message text.
+     */
+    message: {
+      displayName: "Message",
+      type: "string",
+      required: true,
+    },
+    /**
+     * Message id.
+     */
+    id: {
+      displayName: "Message ID",
+      type: "number",
+      required: true,
+    },
+    /**
      * Message type.
      */
     type: {
@@ -58,13 +74,10 @@ export const smartComponentDefinition = {
         },
       ],
     },
-    /**
-     * Message text.
-     */
-    message: {
-      displayName: "Message",
+    title: {
+      displayName: "Title",
       type: "string",
-      required: true,
+      required: false,
     },
     /**
      * Includes dismiss functionality.
@@ -72,19 +85,6 @@ export const smartComponentDefinition = {
     isDismissible: {
       displayName: "Is dismissible",
       type: "boolean",
-      required: false,
-    },
-    /**
-     * Message id.
-     */
-    id: {
-      displayName: "Id",
-      type: "number",
-      required: true,
-    },
-    title: {
-      displayName: "Title",
-      type: "string",
       required: false,
     },
     className: {

--- a/packages/react-sample-library/src/components/Tooltip/index.tsx
+++ b/packages/react-sample-library/src/components/Tooltip/index.tsx
@@ -27,6 +27,22 @@ export const smartComponentDefinition = {
   iconUrl: null,
   fields: {
     /**
+     * Text to display in tooltip
+     */
+    content: {
+      displayName: "Content",
+      type: "string",
+      required: true,
+    },
+    /**
+     * Text to use as the trigger instead of an icon. Leave blank to use the icon.
+     */
+    triggerText: {
+      displayName: "Trigger text",
+      type: "string",
+      required: false,
+    },
+    /**
      * Icon to trigger tooltip
      * @default circleInfo
      */
@@ -48,22 +64,6 @@ export const smartComponentDefinition = {
           value: "circleExclamation",
         },
       ],
-    },
-    /**
-     * Text to display in tooltip
-     */
-    content: {
-      displayName: "Content",
-      type: "string",
-      required: true,
-    },
-    /**
-     * Text to use as the trigger instead of an icon. Leave blank to use the icon.
-     */
-    triggerText: {
-      displayName: "Trigger text",
-      type: "string",
-      required: false,
     },
     /**
      * The accessible text for the trigger. Only necessary when the trigger is an icon.


### PR DESCRIPTION
# Overview

Updates default component definitions to make them easier to understand when displayed in the add-on for insertion. 

# Changes
- Included "URL" in `file` field descriptions making it clear a file URL is expected.
- Badge: Removes the `hasStatusType` field and makes `statusType` an optional field. `hasStatusType` is now deduced from the presence of `statusType` to simulate the discriminated union expected here.
- Re-orders fields to always show required fields first.
- Removes usage of `href` in favour of `URL` when a link is expected. 