### PR TITLE
[PCC 816] Site scoped API keys

### DIFF
--- a/packages/cli/src/cli/commands/token.ts
+++ b/packages/cli/src/cli/commands/token.ts
@@ -6,10 +6,12 @@ import AddOnApiHelper from "../../lib/addonApiHelper";
 import { printTable } from "../../lib/cliDisplay";
 import { errorHandler, HTTPNotFound } from "../exceptions";
 
-export const createToken = errorHandler<void>(async () => {
+export const createToken = errorHandler<{
+  siteId?: string;
+}>(async (args) => {
   const spinner = ora("Creating token...").start();
   try {
-    const apiKey = await AddOnApiHelper.createApiKey();
+    const apiKey = await AddOnApiHelper.createApiKey(args);
     spinner.succeed(`Successfully created token for your user. `);
     console.log("\nToken:", chalk.bold(chalk.green(apiKey)), "\n");
     console.log(

--- a/packages/cli/src/cli/exceptions.ts
+++ b/packages/cli/src/cli/exceptions.ts
@@ -35,7 +35,11 @@ export function errorHandler<T>(
         console.log(chalk.red("Error: User is not logged in."));
         console.log(chalk.yellow('Please run "pcc login" to login.'));
       } else {
-        if (axios.isAxiosError(e) && e.response?.data?.message) {
+        if (
+          axios.isAxiosError(e) &&
+          (e.response?.status ?? 500) < 500 && // Treat internal server errors as unhandled errors
+          e.response?.data?.message
+        ) {
           // Operational error
           console.log(chalk.red(`Error: ${e.response.data.message}`));
         } else {

--- a/packages/cli/src/cli/exceptions.ts
+++ b/packages/cli/src/cli/exceptions.ts
@@ -1,4 +1,5 @@
 import { exit } from "process";
+import axios from "axios";
 import chalk from "chalk";
 
 export class UnhandledError extends Error {
@@ -34,14 +35,21 @@ export function errorHandler<T>(
         console.log(chalk.red("Error: User is not logged in."));
         console.log(chalk.yellow('Please run "pcc login" to login.'));
       } else {
-        console.log(
-          chalk.yellow("\nStack trace:", (e as { stack: string }).stack),
-        );
-        console.log(
-          chalk.red(
-            "Error: Something went wrong. Please contact Pantheon support team.",
-          ),
-        );
+        if (axios.isAxiosError(e) && e.response?.data?.message) {
+          // Operational error
+          console.log(chalk.red(`Error: ${e.response.data.message}`));
+        } else {
+          // Unhandled error
+          console.log(
+            chalk.yellow("\nStack trace:", (e as { stack: string }).stack),
+          );
+          console.log(
+            chalk.red(
+              "Error: Something went wrong. Please contact Pantheon support team.",
+            ),
+          );
+        }
+
         exit(1);
       }
     }

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -162,10 +162,14 @@ yargs(hideBin(process.argv))
         .command(
           "create",
           "Creates new token.",
-          () => {
-            // noop
+          (yargs) => {
+            yargs.option("siteId", {
+              describe:
+                "Site for which you want to create token. The token will only be able to access documents in this site",
+              type: "string",
+            });
           },
-          async () => await createToken(),
+          async (args) => await createToken(args as { siteId?: string }),
         )
         .command(
           "list",

--- a/packages/cli/src/lib/addonApiHelper.ts
+++ b/packages/cli/src/lib/addonApiHelper.ts
@@ -73,12 +73,14 @@ class AddOnApiHelper {
     return resp.data.grantToken as string;
   }
 
-  static async createApiKey(): Promise<string> {
+  static async createApiKey({ siteId }: { siteId?: string }): Promise<string> {
     const idToken = await this.getIdToken();
 
     const resp = await axios.post(
       API_KEY_ENDPOINT,
-      {},
+      {
+        siteId,
+      },
       {
         headers: {
           Authorization: `Bearer ${idToken}`,


### PR DESCRIPTION
# Overview
Adds support for creating site scoped API keys.

The command for creating them looks like: 
```shell
pcc token create --siteId <site id>
```

# Other Changes
- Updates exception logging to log out operational error messages returned from API