### PR TITLE
[PCC-957] Add site connection status listing support

### DIFF
--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -247,12 +247,20 @@ yargs(hideBin(process.argv))
             }),
         )
         .command(
-          "list",
+          "list [options]",
           "Lists existing sites.",
-          () => {
-            // noop
+          (yargs) => {
+            yargs.option("withStatus", {
+              describe: "Include connection statuses of the sites.",
+              type: "boolean",
+              default: false,
+              demandOption: false,
+            });
           },
-          async () => await listSites(),
+          async (args) =>
+            await listSites({
+              withStatus: args.withStatus as boolean,
+            }),
         )
         .command(
           "configure <id> [options]",

--- a/packages/cli/src/lib/addonApiHelper.ts
+++ b/packages/cli/src/lib/addonApiHelper.ts
@@ -213,12 +213,19 @@ class AddOnApiHelper {
     return resp.data.id as string;
   }
 
-  static async listSites(): Promise<Site[]> {
+  static async listSites({
+    withConnectionStatus,
+  }: {
+    withConnectionStatus?: boolean;
+  }): Promise<Site[]> {
     const idToken = await this.getIdToken();
 
     const resp = await axios.get(SITE_ENDPOINT, {
       headers: {
         Authorization: `Bearer ${idToken}`,
+      },
+      params: {
+        withConnectionStatus,
       },
     });
 

--- a/packages/cli/src/lib/cliDisplay.ts
+++ b/packages/cli/src/lib/cliDisplay.ts
@@ -29,8 +29,8 @@ export function printTable(
           const formattedValue =
             typeof row[curr] === "boolean"
               ? row[curr]
-                ? "True"
-                : "False"
+                ? "✅"
+                : "❌"
               : row[curr].toString();
 
           prev[curr] = formattedValue.padEnd(columnPaddings[curr]);

--- a/packages/cli/src/lib/cliDisplay.ts
+++ b/packages/cli/src/lib/cliDisplay.ts
@@ -1,7 +1,9 @@
 import { Console } from "console";
 import { Transform } from "stream";
 
-export function printTable(input: { [key: string]: string | number }[]) {
+export function printTable(
+  input: { [key: string]: string | number | boolean }[],
+) {
   if (input.length === 0) return;
 
   // Adding space padding at the end. console.table doesn't handle it out of the box.
@@ -24,7 +26,14 @@ export function printTable(input: { [key: string]: string | number }[]) {
     inputWithPaddings.push(
       Object.keys(columnPaddings).reduce(
         (prev: { [key: string]: string }, curr) => {
-          prev[curr] = row[curr].toString().padEnd(columnPaddings[curr]);
+          const formattedValue =
+            typeof row[curr] === "boolean"
+              ? row[curr]
+                ? "True"
+                : "False"
+              : row[curr].toString();
+
+          prev[curr] = formattedValue.padEnd(columnPaddings[curr]);
           return prev;
         },
         {},

--- a/packages/cli/src/types/index.d.ts
+++ b/packages/cli/src/types/index.d.ts
@@ -17,6 +17,10 @@ declare type Site = {
   url: string;
   created?: number;
   __isPlayground: boolean;
+  connectionStatus?: {
+    connected: boolean;
+    capabilities: Record<string, boolean>;
+  } | null;
 };
 
 declare type AuthDetails = {


### PR DESCRIPTION
# Changes
Adds new `withStatus` option flag to the `site list` command to support querying for the site's connection status.

# Change Screenshots
## With `withStatus` flag
![Screenshot 2024-02-02 at 13 06 20](https://github.com/pantheon-systems/pantheon-content-cloud-sdk/assets/87580113/1840bdf7-73e9-40e4-8960-7343bf787823)

## Without `withStatus` flag
![Screenshot 2024-02-02 at 13 04 52](https://github.com/pantheon-systems/pantheon-content-cloud-sdk/assets/87580113/222dc96a-aa00-4add-bc2f-0271481e10ba)
