### PR TITLE
[PCC-996] Escape content in browser sdk

### DIFF
--- a/packages/browser/src/elements/pcc-article.ts
+++ b/packages/browser/src/elements/pcc-article.ts
@@ -10,10 +10,10 @@ class PCCArticle extends HTMLElement {
   async connectedCallback() {
     const id = this.getAttribute("id") || undefined;
     const slug = this.getAttribute("slug") || undefined;
-    const disableStyles = this.getAttribute("disable-styles") || undefined;
+    const disableStyles = this.getAttribute("disable-styles") != null;
 
     const config = {
-      disableStyles: Boolean(disableStyles),
+      disableStyles,
     };
 
     if (!id && !slug) {

--- a/packages/browser/src/elements/renderer.ts
+++ b/packages/browser/src/elements/renderer.ts
@@ -82,7 +82,7 @@ export const renderContentNode = (
   }
 
   if (element.data) {
-    node.innerHTML = element.data;
+    node.innerText = element.data;
   }
 
   // Render child nodes recursively


### PR DESCRIPTION
# Changes
- Treats element data in tree node as text content instead of HTML
- Checks for presence of disable-styles instead of the value of the attribute. Allows the attribute to be used like so 
```
<pcc-article disable-styles>
```
instead of 
```
<pcc-article disable-styles="true">
```