### PR TITLE
Remove sharp from deps

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -688,9 +688,6 @@ importers:
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
-      sharp:
-        specifier: ^0.32.6
-        version: 0.32.6
     devDependencies:
       '@testing-library/react':
         specifier: 13.4.0
@@ -773,9 +770,6 @@ importers:
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
-      sharp:
-        specifier: ^0.32.6
-        version: 0.32.6
     devDependencies:
       '@testing-library/react':
         specifier: 13.4.0

--- a/starters/nextjs-starter-ts/package.json
+++ b/starters/nextjs-starter-ts/package.json
@@ -33,8 +33,7 @@
     "next-seo": "^5.15.0",
     "query-string": "^8.1.0",
     "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "sharp": "^0.32.6"
+    "react-dom": "18.2.0"
   },
   "devDependencies": {
     "@testing-library/react": "13.4.0",

--- a/starters/nextjs-starter/package.json
+++ b/starters/nextjs-starter/package.json
@@ -33,8 +33,7 @@
     "next-seo": "^5.15.0",
     "query-string": "^8.1.0",
     "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "sharp": "^0.32.6"
+    "react-dom": "18.2.0"
   },
   "devDependencies": {
     "@testing-library/react": "13.4.0",


### PR DESCRIPTION
# Issue 
Installing Sharp by default opens us up to compatibility issues on platforms where prebuilt binaries aren't available or the tools required to build said binary locally are not available. Next's image functions work without Sharp installed and it can be easily installed if a user needs the image optimization functionality **after** setting up the starter kit