### PR TITLE
[PCC 978] Support defining hero image

### DIFF
--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -10,7 +10,7 @@ export interface Article {
   publishingLevel: keyof typeof PublishingLevel;
   title: string | null;
   updatedAt: number | null;
-  metadata: unknown | null;
+  metadata: Record<string, unknown> | null;
   previewActiveUntil: number | null;
 }
 

--- a/starters/gatsby-starter-ts/gatsby-node.mjs
+++ b/starters/gatsby-starter-ts/gatsby-node.mjs
@@ -26,9 +26,15 @@ const pantheonClient = new PantheonClient({
 });
 
 const createPages = async ({ actions: { createPage } }) => {
-  const articles = await getArticles(pantheonClient, {
-    publishingLevel: "PRODUCTION",
-  });
+  const articles = await getArticles(
+    pantheonClient,
+    {
+      publishingLevel: "PRODUCTION",
+    },
+    {
+      publishStatus: "published",
+    },
+  );
 
   createPage({
     path: `/`,
@@ -55,6 +61,15 @@ const createPages = async ({ actions: { createPage } }) => {
       component: path.resolve("./src/templates/articles/[slug].tsx"),
       context: { article },
     });
+
+    // Create slug-based pages
+    if (article.slug) {
+      createPage({
+        path: `/articles/${article.slug}`,
+        component: path.resolve("./src/templates/articles/[slug].tsx"),
+        context: { article },
+      });
+    }
   });
 };
 

--- a/starters/gatsby-starter-ts/src/components/grid.tsx
+++ b/starters/gatsby-starter-ts/src/components/grid.tsx
@@ -17,8 +17,12 @@ const GridItem = ({ href, imgSrc, altText, title }: Props) => {
     <Link to={href}>
       <div className="flex flex-col h-full overflow-hidden border-2 rounded-lg shadow-lg cursor-pointer hover:border-indigo-500">
         <div className="relative flex-shrink-0 h-40">
-          {imgSrc !== null ? (
-            <img src={imgSrc} alt={altText} style={{ objectFit: "cover" }} />
+          {imgSrc != null ? (
+            <img
+              src={imgSrc}
+              alt={altText || title}
+              className="object-cover w-full h-full"
+            />
           ) : (
             <GradientPlaceholder />
           )}
@@ -32,11 +36,23 @@ const GridItem = ({ href, imgSrc, altText, title }: Props) => {
 };
 
 const PostGridItem = ({ content: article }) => {
-  return <GridItem href={`/articles/${article.id}`} title={article.title} />;
+  return (
+    <GridItem
+      href={`/articles/${article.slug || article.id}`}
+      imgSrc={article.metadata["Hero Image"]}
+      title={article.title}
+    />
+  );
 };
 
 const PageGridItem = ({ content: article }) => {
-  return <GridItem href={`/articles/${article.id}`} title={article.title} />;
+  return (
+    <GridItem
+      href={`/articles/${article.slug || article.id}`}
+      imgSrc={article.metadata["Hero Image"]}
+      title={article.title}
+    />
+  );
 };
 
 export const Grid = ({ children }) => {
@@ -51,7 +67,7 @@ export const Grid = ({ children }) => {
 
 interface GriddedComponentProps {
   data: any[];
-  FallbackComponent?: JSX.Element | undefined;
+  FallbackComponent?: React.ReactNode | undefined;
 }
 
 export const withGrid = (Component) => {
@@ -69,7 +85,7 @@ export const withGrid = (Component) => {
             })}
           </Grid>
         ) : FallbackComponent ? (
-          <FallbackComponent />
+          FallbackComponent
         ) : null}
       </>
     );

--- a/starters/gatsby-starter-ts/src/components/seo.tsx
+++ b/starters/gatsby-starter-ts/src/components/seo.tsx
@@ -11,6 +11,7 @@ interface Props {
   tags?: string[];
   authors?: string[];
   date?: string | undefined;
+  images?: string[];
 }
 
 export default function Seo({
@@ -19,6 +20,7 @@ export default function Seo({
   tags,
   authors,
   date,
+  images,
 }: Props) {
   const meta = {
     ...defaultMeta,
@@ -27,6 +29,7 @@ export default function Seo({
     authors,
     tags,
     date,
+    images,
   };
   return (
     <head>
@@ -37,6 +40,13 @@ export default function Seo({
       <meta property="og:type" content={meta.type} />
       <meta property="og:description" content={meta.description} />
       <meta property="og:title" content={meta.title} />
+      {meta.images && (
+        <>
+          {meta.images.map((url) => (
+            <meta property="og:image" content={url} />
+          ))}
+        </>
+      )}
       {/* Twitter */}
       <meta name="twitter:title" content={meta.title} />
       <meta name="twitter:description" content={meta.description} />

--- a/starters/gatsby-starter-ts/src/templates/articles/[slug].tsx
+++ b/starters/gatsby-starter-ts/src/templates/articles/[slug].tsx
@@ -16,12 +16,18 @@ const getSeoMetadata = (article: Article) => {
       publishedTime = new Date(val.msSinceEpoch).toISOString();
   });
 
+  const images = [
+    article.metadata?.["Hero Image"],
+    // Extend as needed
+  ].filter((i): i is string => typeof i === "string");
+
   return {
     title: article.title,
     description: "Article hosted using Pantheon Content Cloud",
     tags,
     authors,
     publishedTime,
+    images,
   };
 };
 
@@ -35,6 +41,7 @@ export default function PageTemplate({ pageContext: { article } }) {
         tags={seoMetadata.tags}
         authors={seoMetadata.authors}
         date={seoMetadata.publishedTime || undefined}
+        images={seoMetadata.images}
       />
       <div className="max-w-screen-lg mx-auto mt-16 prose">
         <ArticleRenderer

--- a/starters/gatsby-starter/gatsby-node.mjs
+++ b/starters/gatsby-starter/gatsby-node.mjs
@@ -26,9 +26,15 @@ const pantheonClient = new PantheonClient({
 });
 
 const createPages = async ({ actions: { createPage } }) => {
-  const articles = await getArticles(pantheonClient, {
-    publishingLevel: "PRODUCTION",
-  });
+  const articles = await getArticles(
+    pantheonClient,
+    {
+      publishingLevel: "PRODUCTION",
+    },
+    {
+      publishStatus: "published",
+    },
+  );
 
   createPage({
     path: `/`,
@@ -55,6 +61,15 @@ const createPages = async ({ actions: { createPage } }) => {
       component: path.resolve("./src/templates/articles/[slug].js"),
       context: { article },
     });
+
+    // Create slug-based pages
+    if (article.slug) {
+      createPage({
+        path: `/articles/${article.slug}`,
+        component: path.resolve("./src/templates/articles/[slug].tsx"),
+        context: { article },
+      });
+    }
   });
 };
 

--- a/starters/gatsby-starter/src/components/grid.jsx
+++ b/starters/gatsby-starter/src/components/grid.jsx
@@ -1,5 +1,5 @@
-import React from "react";
 import { Link } from "gatsby";
+import React from "react";
 
 const GradientPlaceholder = () => (
   <div className="w-full h-full bg-gradient-to-b from-blue-100 to-blue-500" />
@@ -10,8 +10,12 @@ const GridItem = ({ href, imgSrc, altText, title }) => {
     <Link to={href}>
       <div className="flex flex-col h-full overflow-hidden border-2 rounded-lg shadow-lg cursor-pointer hover:border-indigo-500">
         <div className="relative flex-shrink-0 h-40">
-          {imgSrc !== null ? (
-            <img src={imgSrc} alt={altText} style={{ objectFit: "cover" }} />
+          {imgSrc != null ? (
+            <img
+              src={imgSrc}
+              alt={altText || title}
+              className="object-cover w-full h-full"
+            />
           ) : (
             <GradientPlaceholder />
           )}
@@ -27,8 +31,8 @@ const GridItem = ({ href, imgSrc, altText, title }) => {
 const PostGridItem = ({ content: article }) => {
   return (
     <GridItem
-      href={`/articles/${article.id}`}
-      imgSrc={null}
+      href={`/articles/${article.slug || article.id}`}
+      imgSrc={article.metadata["Hero Image"]}
       title={article.title}
     />
   );
@@ -37,8 +41,8 @@ const PostGridItem = ({ content: article }) => {
 const PageGridItem = ({ content: article }) => {
   return (
     <GridItem
-      href={`/articles/${article.id}`}
-      imgSrc={null}
+      href={`/articles/${article.slug || article.id}`}
+      imgSrc={article.metadata["Hero Image"]}
       title={article.title}
     />
   );
@@ -65,7 +69,7 @@ export const withGrid = (Component) => {
             })}
           </Grid>
         ) : FallbackComponent ? (
-          <FallbackComponent />
+          FallbackComponent
         ) : null}
       </>
     );

--- a/starters/gatsby-starter/src/components/seo.jsx
+++ b/starters/gatsby-starter/src/components/seo.jsx
@@ -5,7 +5,14 @@ const defaultMeta = {
   robots: "follow, index",
 };
 
-export default function Seo({ title, description, tags, authors, date }) {
+export default function Seo({
+  title,
+  description,
+  tags,
+  authors,
+  date,
+  images,
+}) {
   const meta = {
     ...defaultMeta,
     title,
@@ -13,6 +20,7 @@ export default function Seo({ title, description, tags, authors, date }) {
     authors,
     tags,
     date,
+    images,
   };
 
   return (
@@ -24,6 +32,13 @@ export default function Seo({ title, description, tags, authors, date }) {
       <meta property="og:type" content={meta.type} />
       <meta property="og:description" content={meta.description} />
       <meta property="og:title" content={meta.title} />
+      {meta.images && (
+        <>
+          {meta.images.map((url) => (
+            <meta property="og:image" content={url} />
+          ))}
+        </>
+      )}
       {/* Twitter */}
       <meta name="twitter:title" content={meta.title} />
       <meta name="twitter:description" content={meta.description} />

--- a/starters/gatsby-starter/src/templates/articles/[slug].js
+++ b/starters/gatsby-starter/src/templates/articles/[slug].js
@@ -14,12 +14,19 @@ const getSeoMetadata = (article) => {
     else if (key.toLowerCase().trim() === "date" && val.msSinceEpoch)
       publishedTime = new Date(val.msSinceEpoch).toISOString();
   });
+
+  const images = [
+    article.metadata?.["Hero Image"],
+    // Extend as needed
+  ].filter((url) => typeof url === "string");
+
   return {
     title: article.title,
     description: "Article hosted using Pantheon Content Cloud",
     tags,
     authors,
     publishedTime,
+    images,
   };
 };
 
@@ -33,6 +40,7 @@ export default function PageTemplate({ pageContext: { article } }) {
         tags={seoMetadata.tags}
         authors={seoMetadata.authors}
         date={seoMetadata.publishedTime}
+        images={seoMetadata.images}
       />
       <div className="max-w-screen-lg mx-auto mt-16 prose">
         <ArticleRenderer

--- a/starters/nextjs-starter-ts/components/grid.tsx
+++ b/starters/nextjs-starter-ts/components/grid.tsx
@@ -18,22 +18,21 @@ interface Props {
 const GridItem = ({ href, imgSrc, altText, tags, title }: Props) => {
   return (
     <>
-      <div className="flex flex-col rounded-lg shadow-lg overflow-hidden h-full">
+      <div className="flex flex-col h-full overflow-hidden rounded-lg shadow-lg">
         <Link passHref href={href}>
-          <div className="flex-shrink-0 relative h-40 hover:border-indigo-500 cursor-pointer border-2s">
-            {imgSrc !== null ? (
-              <Image
+          <div className="relative flex-shrink-0 h-40 cursor-pointer hover:border-indigo-500 border-2s">
+            {imgSrc != null ? (
+              <img
                 src={imgSrc}
-                fill
                 alt={altText || title}
-                style={{ objectFit: "cover" }}
+                className="object-cover w-full h-full"
               />
             ) : (
               <GradientPlaceholder />
             )}
           </div>
         </Link>
-        <div className="my-4 mx-6 text-xl leading-7 font-semibold text-gray-900">
+        <div className="mx-6 my-4 text-xl font-semibold leading-7 text-gray-900">
           <Link passHref href={href}>
             <div className="hover:scale-105">{title} &rarr;</div>
           </Link>
@@ -47,8 +46,8 @@ const GridItem = ({ href, imgSrc, altText, tags, title }: Props) => {
 const PostGridItem = ({ content: article }) => {
   return (
     <GridItem
-      href={`/articles/${article.id}`}
-      imgSrc={null}
+      href={`/articles/${article.slug || article.id}`}
+      imgSrc={article.metadata["Hero Image"]}
       title={article.title}
       tags={article.tags}
     />
@@ -58,8 +57,8 @@ const PostGridItem = ({ content: article }) => {
 const PageGridItem = ({ content: article }) => {
   return (
     <GridItem
-      href={`/articles/${article.id}`}
-      imgSrc={null}
+      href={`/articles/${article.slug || article.id}`}
+      imgSrc={article.metadata["Hero Image"]}
       title={article.title}
       tags={article.tags}
     />

--- a/starters/nextjs-starter-ts/pages/articles/[...uri].tsx
+++ b/starters/nextjs-starter-ts/pages/articles/[...uri].tsx
@@ -29,6 +29,7 @@ export default function ArticlePage({ article, grant }: ArticlePageProps) {
             type: "website",
             title: seoMetadata.title,
             description: seoMetadata.description,
+            images: seoMetadata.images,
             article: {
               authors: seoMetadata.authors,
               tags: seoMetadata.tags,
@@ -112,11 +113,20 @@ const getSeoMetadata = (article) => {
       publishedTime = new Date(val.msSinceEpoch).toISOString();
   });
 
+  const images = [
+    ...(typeof article.metadata["Hero Image"] === "string" && [
+      {
+        url: article.metadata["Hero Image"],
+      },
+    ]),
+  ];
+
   return {
     title: article.title,
     description: "Article hosted using Pantheon Content Cloud",
     tags,
     authors,
     publishedTime,
+    images,
   };
 };

--- a/starters/nextjs-starter-ts/pages/articles/[...uri].tsx
+++ b/starters/nextjs-starter-ts/pages/articles/[...uri].tsx
@@ -1,4 +1,5 @@
 import {
+  ArticleWithoutContent,
   PantheonProvider,
   type Article,
 } from "@pantheon-systems/pcc-react-sdk";
@@ -113,13 +114,12 @@ const getSeoMetadata = (article) => {
       publishedTime = new Date(val.msSinceEpoch).toISOString();
   });
 
-  const images = [
-    ...(typeof article.metadata["Hero Image"] === "string" && [
-      {
-        url: article.metadata["Hero Image"],
-      },
-    ]),
-  ];
+  const imageProperties = [
+    article.metadata?.["Hero Image"],
+    // Extend as needed
+  ]
+    .filter((url): url is string => typeof url === "string")
+    .map((url) => ({ url }));
 
   return {
     title: article.title,
@@ -127,6 +127,6 @@ const getSeoMetadata = (article) => {
     tags,
     authors,
     publishedTime,
-    images,
+    images: imageProperties,
   };
 };

--- a/starters/nextjs-starter/components/grid.jsx
+++ b/starters/nextjs-starter/components/grid.jsx
@@ -10,22 +10,21 @@ const GradientPlaceholder = () => (
 const GridItem = ({ href, imgSrc, altText, tags, title }) => {
   return (
     <>
-      <div className="flex flex-col rounded-lg shadow-lg overflow-hidden h-full">
+      <div className="flex flex-col h-full overflow-hidden rounded-lg shadow-lg">
         <Link passHref href={href}>
-          <div className="flex-shrink-0 relative h-40 hover:border-indigo-500 cursor-pointer border-2s">
-            {imgSrc !== null ? (
-              <Image
+          <div className="relative flex-shrink-0 h-40 cursor-pointer hover:border-indigo-500 border-2s">
+            {imgSrc != null ? (
+              <img
                 src={imgSrc}
-                fill
                 alt={altText || title}
-                style={{ objectFit: "cover" }}
+                className="object-cover w-full h-full"
               />
             ) : (
               <GradientPlaceholder />
             )}
           </div>
         </Link>
-        <div className="my-4 mx-6 text-xl leading-7 font-semibold text-gray-900">
+        <div className="mx-6 my-4 text-xl font-semibold leading-7 text-gray-900">
           <Link passHref href={href}>
             <div className="hover:scale-105">{title} &rarr;</div>
           </Link>
@@ -39,8 +38,8 @@ const GridItem = ({ href, imgSrc, altText, tags, title }) => {
 const PostGridItem = ({ content: article }) => {
   return (
     <GridItem
-      href={`/articles/${article.id}`}
-      imgSrc={null}
+      href={`/articles/${article.slug || article.id}`}
+      imgSrc={article.metadata["Hero Image"]}
       title={article.title}
       tags={article.tags}
     />
@@ -50,8 +49,8 @@ const PostGridItem = ({ content: article }) => {
 const PageGridItem = ({ content: article }) => {
   return (
     <GridItem
-      href={`/articles/${article.id}`}
-      imgSrc={null}
+      href={`/articles/${article.slug || article.id}`}
+      imgSrc={article.metadata["Hero Image"]}
       title={article.title}
       tags={article.tags}
     />

--- a/starters/nextjs-starter/pages/articles/[...uri].jsx
+++ b/starters/nextjs-starter/pages/articles/[...uri].jsx
@@ -21,6 +21,7 @@ export default function ArticlePage({ article, grant }) {
             type: "website",
             title: seoMetadata.title,
             description: seoMetadata.description,
+            images: seoMetadata.images,
             article: {
               authors: seoMetadata.authors,
               tags: seoMetadata.tags,
@@ -100,11 +101,20 @@ const getSeoMetadata = (article) => {
       publishedTime = new Date(val.msSinceEpoch).toISOString();
   });
 
+  const images = [
+    ...(typeof article.metadata["Hero Image"] === "string" && [
+      {
+        url: article.metadata["Hero Image"],
+      },
+    ]),
+  ];
+
   return {
     title: article.title,
     description: "Article hosted using Pantheon Content Cloud",
     tags,
     authors,
     publishedTime,
+    images,
   };
 };

--- a/starters/nextjs-starter/pages/articles/[...uri].jsx
+++ b/starters/nextjs-starter/pages/articles/[...uri].jsx
@@ -101,13 +101,12 @@ const getSeoMetadata = (article) => {
       publishedTime = new Date(val.msSinceEpoch).toISOString();
   });
 
-  const images = [
-    ...(typeof article.metadata["Hero Image"] === "string" && [
-      {
-        url: article.metadata["Hero Image"],
-      },
-    ]),
-  ];
+  const imageProperties = [
+    article.metadata?.["Hero Image"],
+    // Extend as needed
+  ]
+    .filter((url) => typeof url === "string")
+    .map((url) => ({ url }));
 
   return {
     title: article.title,
@@ -115,6 +114,6 @@ const getSeoMetadata = (article) => {
     tags,
     authors,
     publishedTime,
-    images,
+    images: imageProperties,
   };
 };

--- a/starters/vue-starter-ts/components/ArticleLink.vue
+++ b/starters/vue-starter-ts/components/ArticleLink.vue
@@ -1,33 +1,43 @@
 <script lang="ts">
 import type { PropType } from "vue";
+import type { ArticleWithoutContent } from "@pantheon-systems/pcc-vue-sdk";
 
 export default {
   props: {
-    id: {
-      type: String,
-      required: true,
-    },
-    title: {
-      type: String,
-      required: true,
-    },
-    tags: {
-      type: Array as PropType<string[]>,
+    article: {
+      type: Object as PropType<ArticleWithoutContent>,
       required: true,
     },
   },
+  computed: {
+    heroImage(): string | null {
+      const heroImage = this.article.metadata?.['Hero Image'];
+      
+      return typeof heroImage === 'string' ? heroImage : null;
+    },
+    identifier(): string {
+      return this.article.slug || this.article.id;
+    },
+    tags(): string[] {
+      return this.article.tags || [];
+    },
+    title(): string {
+      return this.article.title || "Untitled Article";
+    },
+  },  
 }
 </script>
 
 <template>
   <div class="flex flex-col h-full overflow-hidden rounded-lg shadow-lg">
-    <a :href="/articles/ + id">
-      <div class="relative flex-shrink-0 h-40 cursor-pointer hover:border-indigo-500 border-2s">
-        <div class="w-full h-full bg-gradient-to-b from-blue-100 to-green-500"></div>
+    <a :href="/articles/ + identifier">
+      <div class="relative flex-shrink-0 h-40 cursor-pointer hover:border-indigo-500 border-2s not-prose">
+        <img v-if="heroImage != null" :src="heroImage" alt="Article Hero Image" class="object-cover w-full h-full" />
+        <div v-else class="w-full h-full bg-gradient-to-b from-blue-100 to-green-500"></div>
       </div>
     </a>
     <div class="mx-6 my-4 text-xl font-semibold leading-7 text-gray-900">
-      <a :href="/articles/ + id">
+      <a :href="/articles/ + identifier">
         <div class="hover:scale-105">{{ title }}</div>
       </a>
       <div class="mt-2 text-sm leading-[1.25rem] text-theme-bg-black">

--- a/starters/vue-starter-ts/pages/index.vue
+++ b/starters/vue-starter-ts/pages/index.vue
@@ -29,8 +29,7 @@ const { data, error } = await useFetch<ArticleWithoutContent[]>("/api/articles/"
         Loading...
       </h2>
       <div v-else class="grid gap-5 mx-auto mt-12 max-w-content lg:max-w-screen-lg lg:grid-cols-3">
-        <article-link v-for="article in data" :key="article.id" :id="article.id" :title="article.title || 'Untitled'"
-          :tags="article.tags || []" />
+        <article-link v-for="article in data" :key="article.id" :article="article" />
       </div>
     </section>
   </div>

--- a/starters/vue-starter-ts/server/lib/pantheon.ts
+++ b/starters/vue-starter-ts/server/lib/pantheon.ts
@@ -4,7 +4,7 @@ import {
   type SmartComponentMap,
 } from "@pantheon-systems/pcc-vue-sdk";
 
-const { PCC_SITE_ID, PCC_TOKEN } = process.env;
+const { PCC_SITE_ID, PCC_TOKEN, PCC_HOST } = process.env;
 
 export const getPantheonClient = (options?: Partial<PantheonClientConfig>) => {
   if (!PCC_SITE_ID) {
@@ -17,7 +17,8 @@ export const getPantheonClient = (options?: Partial<PantheonClientConfig>) => {
 
   return new PantheonClient({
     siteId: PCC_SITE_ID,
-    apiKey: PCC_TOKEN,
+    token: PCC_TOKEN,
+    pccHost: PCC_HOST,
     ...options,
   });
 };

--- a/starters/vue-starter/components/ArticleLink.vue
+++ b/starters/vue-starter/components/ArticleLink.vue
@@ -1,31 +1,40 @@
 <script>
 export default {
   props: {
-    id: {
-      type: String,
-      required: true,
-    },
-    title: {
-      type: String,
-      required: true,
-    },
-    tags: {
-      type: Array,
+    article: {
+      type: Object,
       required: true,
     },
   },
+  computed: {
+    heroImage() {
+      const heroImage = this.article.metadata?.['Hero Image'];
+      
+      return typeof heroImage === 'string' ? heroImage : null;
+    },
+    identifier() {
+      return this.article.slug || this.article.id;
+    },
+    tags() {
+      return this.article.tags || [];
+    },
+    title() {
+      return this.article.title || "Untitled Article";
+    },
+  }
 }
 </script>
 
 <template>
   <div class="flex flex-col h-full overflow-hidden rounded-lg shadow-lg">
-    <a :href="/articles/ + id">
-      <div class="relative flex-shrink-0 h-40 cursor-pointer hover:border-indigo-500 border-2s">
-        <div class="w-full h-full bg-gradient-to-b from-blue-100 to-green-500"></div>
+    <a :href="/articles/ + identifier">
+      <div class="relative flex-shrink-0 h-40 cursor-pointer hover:border-indigo-500 border-2s not-prose">
+        <img v-if="heroImage != null" :src="heroImage" alt="Article Hero Image" class="object-cover w-full h-full" />
+        <div v-else class="w-full h-full bg-gradient-to-b from-blue-100 to-green-500"></div>
       </div>
     </a>
     <div class="mx-6 my-4 text-xl font-semibold leading-7 text-gray-900">
-      <a :href="/articles/ + id">
+      <a :href="/articles/ + identifier">
         <div class="hover:scale-105">{{ title }}</div>
       </a>
       <div class="mt-2 text-sm leading-[1.25rem] text-theme-bg-black">

--- a/starters/vue-starter/pages/index.vue
+++ b/starters/vue-starter/pages/index.vue
@@ -27,8 +27,7 @@ const { data, error } = await useFetch("/api/articles/")
         Loading...
       </h2>
       <div v-else class="grid gap-5 mx-auto mt-12 max-w-content lg:max-w-screen-lg lg:grid-cols-3">
-        <article-link v-for="article in data" :key="article.id" :id="article.id" :title="article.title || 'Untitled'"
-          :tags="article.tags || []" />
+        <article-link v-for="article in data" :key="article.id" :article="article"/>
       </div>
     </section>
   </div>

--- a/starters/vue-starter/server/lib/pantheon.js
+++ b/starters/vue-starter/server/lib/pantheon.js
@@ -1,6 +1,6 @@
 import { PantheonClient } from "@pantheon-systems/pcc-vue-sdk";
 
-const { PCC_SITE_ID, PCC_TOKEN } = process.env;
+const { PCC_SITE_ID, PCC_TOKEN, PCC_HOST } = process.env;
 
 export const getPantheonClient = (options) => {
   if (!PCC_SITE_ID) {
@@ -13,7 +13,8 @@ export const getPantheonClient = (options) => {
 
   return new PantheonClient({
     siteId: PCC_SITE_ID,
-    apiKey: PCC_TOKEN,
+    token: PCC_TOKEN,
+    pccHost: PCC_HOST,
     ...options,
   });
 };


### PR DESCRIPTION
# Overview
Adds support for defining an article's listing hero image through metadata

# Other Changes
- Updates `core` `Article` type to represent metadata as an object instead of unknown
- Adds support for custom PCC Hosts in Vue starters
- Only show published pages in Gatsby starter
- Add slug based routing support to Gatsby starter

# Screenshots
## Add-on
![Screenshot 2024-02-23 at 16 49 29](https://github.com/pantheon-systems/pantheon-content-cloud-sdk/assets/87580113/05cf8f60-a1ff-40bf-909e-4c00a4f4f98a)
## Next.js starters
![Screenshot 2024-02-23 at 16 16 00](https://github.com/pantheon-systems/pantheon-content-cloud-sdk/assets/87580113/79f45e88-a8d4-4381-baae-6f6b141fc953)
## Vue starters
![Screenshot 2024-02-23 at 16 15 44](https://github.com/pantheon-systems/pantheon-content-cloud-sdk/assets/87580113/5d8bccd6-2120-4566-8637-f0adb2ac9f49)
## Gatsby starters
![Screenshot 2024-02-23 at 17 01 21](https://github.com/pantheon-systems/pantheon-content-cloud-sdk/assets/87580113/c3239c3d-1420-44ec-9abb-72c3d7fe3348)

