### PR TITLE
[PCC-1059, PCC-1060] Align starter kits default styling with source document styles

### DIFF
--- a/local_testing/testpages/app/globals.css
+++ b/local_testing/testpages/app/globals.css
@@ -25,3 +25,8 @@ body {
     )
     rgb(var(--background-start-rgb));
 }
+
+/* Revert custom font's bullet rendering styles */
+li::before {
+  font-family: auto;
+}

--- a/starters/gatsby-starter-ts/src/styles/global.css
+++ b/starters/gatsby-starter-ts/src/styles/global.css
@@ -1,3 +1,8 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Revert custom font's bullet rendering styles */
+li::before {
+  font-family: auto;
+}

--- a/starters/gatsby-starter-ts/src/templates/articles/[slug].tsx
+++ b/starters/gatsby-starter-ts/src/templates/articles/[slug].tsx
@@ -43,7 +43,7 @@ export default function PageTemplate({ pageContext: { article } }) {
         date={seoMetadata.publishedTime || undefined}
         images={seoMetadata.images}
       />
-      <div className="max-w-screen-lg mx-auto mt-16 prose">
+      <div className="max-w-screen-lg mx-auto mt-16 prose text-black">
         <ArticleRenderer
           article={article}
           renderTitle={(titleElement) => (

--- a/starters/gatsby-starter-ts/tailwind.config.js
+++ b/starters/gatsby-starter-ts/tailwind.config.js
@@ -6,7 +6,17 @@ module.exports = {
     `./src/templates/**/*.{js,jsx,ts,tsx}`,
   ],
   theme: {
-    extend: {},
+    extend: {
+      typography: () => ({
+        DEFAULT: {
+          css: {
+            a: {
+              color: "rgb(17, 85, 204)", // "dark cornflower blue 2" in Google Docs
+            },
+          },
+        },
+      }),
+    },
   },
   plugins: [require("@tailwindcss/typography")],
 };

--- a/starters/gatsby-starter/src/styles/global.css
+++ b/starters/gatsby-starter/src/styles/global.css
@@ -1,3 +1,8 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Revert custom font's bullet rendering styles */
+li::before {
+  font-family: auto;
+}

--- a/starters/gatsby-starter/src/templates/articles/[slug].js
+++ b/starters/gatsby-starter/src/templates/articles/[slug].js
@@ -42,7 +42,7 @@ export default function PageTemplate({ pageContext: { article } }) {
         date={seoMetadata.publishedTime}
         images={seoMetadata.images}
       />
-      <div className="max-w-screen-lg mx-auto mt-16 prose">
+      <div className="max-w-screen-lg mx-auto mt-16 prose text-black">
         <ArticleRenderer
           article={article}
           renderTitle={(titleElement) => (

--- a/starters/gatsby-starter/tailwind.config.js
+++ b/starters/gatsby-starter/tailwind.config.js
@@ -6,7 +6,17 @@ module.exports = {
     `./src/templates/**/*.{js,jsx,ts,tsx}`,
   ],
   theme: {
-    extend: {},
+    extend: {
+      typography: () => ({
+        DEFAULT: {
+          css: {
+            a: {
+              color: "rgb(17, 85, 204)", // "dark cornflower blue 2" in Google Docs
+            },
+          },
+        },
+      }),
+    },
   },
   plugins: [require("@tailwindcss/typography")],
 };

--- a/starters/nextjs-starter-ts/pages/articles/[...uri].tsx
+++ b/starters/nextjs-starter-ts/pages/articles/[...uri].tsx
@@ -41,7 +41,7 @@ export default function ArticlePage({ article, grant }: ArticlePageProps) {
           }}
         />
 
-        <div className="max-w-screen-lg mx-auto mt-16 prose">
+        <div className="max-w-screen-lg mx-auto mt-16 prose text-black text-black">
           <ArticleView article={article} />
 
           <Tags tags={article?.tags} />

--- a/starters/nextjs-starter-ts/pages/articles/[...uri].tsx
+++ b/starters/nextjs-starter-ts/pages/articles/[...uri].tsx
@@ -41,7 +41,7 @@ export default function ArticlePage({ article, grant }: ArticlePageProps) {
           }}
         />
 
-        <div className="max-w-screen-lg mx-auto mt-16 prose text-black text-black">
+        <div className="max-w-screen-lg mx-auto mt-16 prose text-black">
           <ArticleView article={article} />
 
           <Tags tags={article?.tags} />

--- a/starters/nextjs-starter-ts/pages/experimental/content-only/[...uri].tsx
+++ b/starters/nextjs-starter-ts/pages/experimental/content-only/[...uri].tsx
@@ -39,7 +39,7 @@ export default function ArticlePage({ article, grant }: ArticlePageProps) {
           }}
         />
 
-        <div className="max-w-screen-lg mx-auto mt-16 prose">
+        <div className="max-w-screen-lg mx-auto mt-16 prose text-black">
           <ArticleView article={article} onlyContent={true} />
 
           <Tags tags={article?.tags} />

--- a/starters/nextjs-starter-ts/styles/globals.css
+++ b/starters/nextjs-starter-ts/styles/globals.css
@@ -1,4 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-

--- a/starters/nextjs-starter-ts/styles/globals.css
+++ b/starters/nextjs-starter-ts/styles/globals.css
@@ -1,3 +1,8 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Revert custom font's bullet rendering styles */
+li::before {
+  font-family: auto;
+}

--- a/starters/nextjs-starter-ts/tailwind.config.cjs
+++ b/starters/nextjs-starter-ts/tailwind.config.cjs
@@ -5,7 +5,17 @@ module.exports = {
     "./src/**/*.{js,jsx,ts,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      typography: () => ({
+        DEFAULT: {
+          css: {
+            a: {
+              color: "rgb(17, 85, 204)", // "dark cornflower blue 2" in Google Docs
+            },
+          },
+        },
+      }),
+    },
   },
   plugins: [require("@tailwindcss/typography")],
 };

--- a/starters/nextjs-starter/pages/articles/[...uri].jsx
+++ b/starters/nextjs-starter/pages/articles/[...uri].jsx
@@ -32,7 +32,7 @@ export default function ArticlePage({ article, grant }) {
           }}
         />
 
-        <div className="max-w-screen-lg mx-auto mt-16 prose">
+        <div className="max-w-screen-lg mx-auto mt-16 prose text-black">
           <ArticleView article={article} />
 
           <Tags tags={article?.tags} />

--- a/starters/nextjs-starter/styles/globals.css
+++ b/starters/nextjs-starter/styles/globals.css
@@ -2,3 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Revert custom font's bullet rendering styles */
+li::before {
+  font-family: auto;
+}

--- a/starters/nextjs-starter/tailwind.config.cjs
+++ b/starters/nextjs-starter/tailwind.config.cjs
@@ -5,7 +5,17 @@ module.exports = {
     "./src/**/*.{js,jsx,ts,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      typography: () => ({
+        DEFAULT: {
+          css: {
+            a: {
+              color: "rgb(17, 85, 204)", // "dark cornflower blue 2" in Google Docs
+            },
+          },
+        },
+      }),
+    },
   },
   plugins: [require("@tailwindcss/typography")],
 };

--- a/starters/vue-starter-ts/assets/css/main.css
+++ b/starters/vue-starter-ts/assets/css/main.css
@@ -1,3 +1,8 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Revert custom font's bullet rendering styles */
+li::before {
+  font-family: auto;
+}

--- a/starters/vue-starter-ts/components/article/ArticleView.vue
+++ b/starters/vue-starter-ts/components/article/ArticleView.vue
@@ -24,7 +24,7 @@ const smartComponentMap = {
 </script>
 
 <template>
-  <div class="max-w-screen-lg mx-auto mt-16 prose">
+  <div class="max-w-screen-lg mx-auto mt-16 prose text-black">
     <h2 v-if="error" class="text-red-500">
       Failed to load article, please try again.
     </h2>

--- a/starters/vue-starter-ts/tailwind.config.js
+++ b/starters/vue-starter-ts/tailwind.config.js
@@ -8,7 +8,17 @@ export default {
     "./app.vue",
   ],
   theme: {
-    extend: {},
+    extend: {
+      typography: () => ({
+        DEFAULT: {
+          css: {
+            a: {
+              color: "rgb(17, 85, 204)", // "dark cornflower blue 2" in Google Docs
+            },
+          },
+        },
+      }),
+    },
   },
   plugins: [require("@tailwindcss/typography")],
 };

--- a/starters/vue-starter/assets/css/main.css
+++ b/starters/vue-starter/assets/css/main.css
@@ -1,3 +1,8 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Revert custom font's bullet rendering styles */
+li::before {
+  font-family: auto;
+}

--- a/starters/vue-starter/components/article/ArticleView.vue
+++ b/starters/vue-starter/components/article/ArticleView.vue
@@ -22,7 +22,7 @@ const smartComponentMap = {
 </script>
 
 <template>
-  <div class="max-w-screen-lg mx-auto mt-16 prose">
+  <div class="max-w-screen-lg mx-auto mt-16 prose text-black">
     <h2 v-if="error" class="text-red-500">
       Failed to load article, please try again.
     </h2>

--- a/starters/vue-starter/tailwind.config.js
+++ b/starters/vue-starter/tailwind.config.js
@@ -8,7 +8,17 @@ export default {
     "./app.vue",
   ],
   theme: {
-    extend: {},
+    extend: {
+      typography: () => ({
+        DEFAULT: {
+          css: {
+            a: {
+              color: "rgb(17, 85, 204)", // "dark cornflower blue 2" in Google Docs
+            },
+          },
+        },
+      }),
+    },
   },
   plugins: [require("@tailwindcss/typography")],
 };


### PR DESCRIPTION
# Changes
- Removes default grayish color on prose content. Set to black by default on all starter kits
- Fixes the rendering of list bullets in starter kits
- Adds default blue link style to links		