### PR TITLE
V3.3.0

### DIFF
--- a/.changeset/twenty-trainers-move.md
+++ b/.changeset/twenty-trainers-move.md
@@ -1,9 +1,0 @@
----
-"@pantheon-systems/pcc-react-sdk": minor
-"@pantheon-systems/pcc-vue-sdk": minor
----
-
-Add experimental flag "useUnintrusiveTitleRendering" which will use the new way
-of rendering titles, where the document's content will not be affected. The old
-(and still default) way will forcibly move the detected title element to the top
-of the document when rendering.

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pantheon-systems/pcc-browser-sdk
 
+## 3.3.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @pantheon-systems/pcc-sdk-core@3.3.0
+
 ## 3.2.1
 
 ### Patch Changes

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -2,7 +2,7 @@
   "name": "@pantheon-systems/pcc-browser-sdk",
   "author": "@pantheon-systems",
   "description": "Pantheon Content Cloud Browser SDK",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "main": "dist/index.js",
   "files": [
     "dist",
@@ -21,6 +21,6 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@pantheon-systems/pcc-sdk-core": "^3.2.1"
+    "@pantheon-systems/pcc-sdk-core": "^3.3.0"
   }
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pantheon-systems/pcc-cli
 
+## 3.3.0
+
+### Patch Changes
+
+- Improved preview & publish from the CLI.
+- Updated dependencies
+  - @pantheon-systems/pcc-sdk-core@3.3.0
+
 ## 3.2.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,7 @@
   "name": "@pantheon-systems/pcc-cli",
   "author": "@pantheon-systems",
   "description": "Pantheon Content Cloud CLI",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "type": "module",
   "license": "MIT",
   "keywords": [
@@ -37,7 +37,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@pantheon-systems/pcc-sdk-core": "~3.2.1",
+    "@pantheon-systems/pcc-sdk-core": "~3.3.0",
     "axios": "^1.6.7",
     "bluebird": "^3.7.2",
     "boxen": "^7.1.1",

--- a/packages/cli/src/cli/commands/init.test.ts
+++ b/packages/cli/src/cli/commands/init.test.ts
@@ -28,8 +28,8 @@ test("should be able to init starter kit for nextjs template", async () => {
 
   await executePCC("init", [appFolder, "--template", "nextjs", "--use-pnpm"]);
 
-  // Eslint not initialized
-  expect(fs.existsSync(`${appFolder}/.eslintrc.json`)).toBe(false);
+  // Eslint should be initialized
+  expect(fs.existsSync(`${appFolder}/.eslintrc.json`)).toBe(true);
 
   // Checking if primary required files for Nextjs starter kit are created.
   expect(fs.existsSync(`${appFolder}/next.config.js`)).toBe(true);
@@ -51,8 +51,8 @@ test("should be able to init starter kit for gatsby template", async () => {
 
   await executePCC("init", [appFolder, "--template", "gatsby", "--use-pnpm"]);
 
-  // Eslint not initialized
-  expect(fs.existsSync(`${appFolder}/.eslintrc.json`)).toBe(false);
+  // Eslint should be initialized
+  expect(fs.existsSync(`${appFolder}/.eslintrc.json`)).toBe(true);
 
   // Checking if primary required files for Gatsby starter kit are created.
   expect(fs.existsSync(`${appFolder}/gatsby-browser.js`)).toBe(true);
@@ -81,8 +81,8 @@ test("should be able to init starter kit for nextjs template with typescript", a
     "--ts",
   ]);
 
-  // Eslint not initialized
-  expect(fs.existsSync(`${appFolder}/.eslintrc.json`)).toBe(false);
+  // Eslint should be initialized
+  expect(fs.existsSync(`${appFolder}/.eslintrc.json`)).toBe(true);
 
   // Checking if primary required files for Nextjs starter kit are created.
   expect(fs.existsSync(`${appFolder}/next.config.js`)).toBe(true);
@@ -107,8 +107,8 @@ test("should be able to init starter kit for gatsby template with typescript", a
   // Check that TypesScript source files exist.
   expect(fs.existsSync(`${appFolder}/src/templates/index.tsx`)).toBe(true);
 
-  // Eslint not initialized
-  expect(fs.existsSync(`${appFolder}/.eslintrc.json`)).toBe(false);
+  // Eslint should be initialized
+  expect(fs.existsSync(`${appFolder}/.eslintrc.json`)).toBe(true);
 
   // Checking if primary required files for Gatsby starter kit are created
   expect(fs.existsSync(`${appFolder}/gatsby-browser.js`)).toBe(true);

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pantheon-systems/pcc-sdk-core
 
+## 3.3.0
+
+### Patch Changes
+
+- Fixed implementation of PCCConvenienceFunctions.getArticleBySlugOrId
+
 ## 3.2.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "@pantheon-systems/pcc-sdk-core",
   "author": "@pantheon-systems",
   "description": "Pantheon Content Cloud SDK Core",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react-sample-library/CHANGELOG.md
+++ b/packages/react-sample-library/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @pantheon-systems/pcc-vue-sdk
 
+## 3.3.0
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [24be191]
+  - @pantheon-systems/pcc-sdk-core@3.3.0
+  - @pantheon-systems/pcc-react-sdk@3.3.0
+
 ## 3.2.1
 
 ### Patch Changes

--- a/packages/react-sample-library/package.json
+++ b/packages/react-sample-library/package.json
@@ -2,7 +2,7 @@
   "name": "@pantheon-systems/pcc-react-sample-library",
   "author": "@pantheon-systems",
   "description": "Pantheon Content Cloud Sample Component Library for React",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -68,8 +68,8 @@
     }
   },
   "dependencies": {
-    "@pantheon-systems/pcc-react-sdk": "~3.2.1",
-    "@pantheon-systems/pcc-sdk-core": "~3.2.1",
+    "@pantheon-systems/pcc-react-sdk": "~3.3.0",
+    "@pantheon-systems/pcc-sdk-core": "~3.3.0",
     "@pantheon-systems/pds-toolkit-react": "1.0.0-dev.55"
   },
   "sideEffects": false

--- a/packages/react-sdk/CHANGELOG.md
+++ b/packages/react-sdk/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @pantheon-systems/pcc-react-sdk
 
+## 3.3.0
+
+### Minor Changes
+
+- 24be191: Add experimental flag "useUnintrusiveTitleRendering" which will use
+  the new way of rendering titles, where the document's content will not be
+  affected. The old (and still default) way will forcibly move the detected
+  title element to the top of the document when rendering.
+
+### Patch Changes
+
+- Updated dependencies
+  - @pantheon-systems/pcc-sdk-core@3.3.0
+
 ## 3.2.1
 
 ### Patch Changes

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -2,7 +2,7 @@
   "name": "@pantheon-systems/pcc-react-sdk",
   "author": "@pantheon-systems",
   "description": "Pantheon Content Cloud React SDK",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "license": "MIT",
   "keywords": [
     "pcc",
@@ -94,7 +94,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.9.5",
-    "@pantheon-systems/pcc-sdk-core": "~3.2.1",
+    "@pantheon-systems/pcc-sdk-core": "~3.3.0",
     "framer-motion": "^10.18.0",
     "goober": "^2.1.14",
     "graphql": "^16.8.1",

--- a/packages/vue-sdk/CHANGELOG.md
+++ b/packages/vue-sdk/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @pantheon-systems/pcc-vue-sdk
 
+## 3.3.0
+
+### Minor Changes
+
+- 24be191: Add experimental flag "useUnintrusiveTitleRendering" which will use
+  the new way of rendering titles, where the document's content will not be
+  affected. The old (and still default) way will forcibly move the detected
+  title element to the top of the document when rendering.
+
+### Patch Changes
+
+- Updated dependencies
+  - @pantheon-systems/pcc-sdk-core@3.3.0
+
 ## 3.2.1
 
 ### Patch Changes

--- a/packages/vue-sdk/package.json
+++ b/packages/vue-sdk/package.json
@@ -2,7 +2,7 @@
   "name": "@pantheon-systems/pcc-vue-sdk",
   "author": "@pantheon-systems",
   "description": "Pantheon Content Cloud Vue SDK",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -81,7 +81,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.9.5",
-    "@pantheon-systems/pcc-sdk-core": "~3.2.1",
+    "@pantheon-systems/pcc-sdk-core": "~3.3.0",
     "@vue/apollo-composable": "4.0.0-beta.12",
     "floating-vue": "2.0.0-beta.24",
     "graphql": "^16.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,7 +118,7 @@ importers:
   packages/browser:
     dependencies:
       '@pantheon-systems/pcc-sdk-core':
-        specifier: ^3.2.1
+        specifier: ^3.3.0
         version: link:../core
     devDependencies:
       eslint:
@@ -137,7 +137,7 @@ importers:
   packages/cli:
     dependencies:
       '@pantheon-systems/pcc-sdk-core':
-        specifier: ~3.2.1
+        specifier: ~3.3.0
         version: link:../core
       axios:
         specifier: ^1.6.7
@@ -298,10 +298,10 @@ importers:
   packages/react-sample-library:
     dependencies:
       '@pantheon-systems/pcc-react-sdk':
-        specifier: ~3.2.1
+        specifier: ~3.3.0
         version: link:../react-sdk
       '@pantheon-systems/pcc-sdk-core':
-        specifier: ~3.2.1
+        specifier: ~3.3.0
         version: link:../core
       '@pantheon-systems/pds-toolkit-react':
         specifier: 1.0.0-dev.55
@@ -377,7 +377,7 @@ importers:
         specifier: ^3.9.5
         version: 3.9.5(@types/react@18.2.60)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
       '@pantheon-systems/pcc-sdk-core':
-        specifier: ~3.2.1
+        specifier: ~3.3.0
         version: link:../core
       '@types/react':
         specifier: '>=18'
@@ -489,7 +489,7 @@ importers:
         specifier: ^3.9.5
         version: 3.9.5(graphql-ws@5.15.0)(graphql@16.8.1)
       '@pantheon-systems/pcc-sdk-core':
-        specifier: ~3.2.1
+        specifier: ~3.3.0
         version: link:../core
       '@vue/apollo-composable':
         specifier: 4.0.0-beta.12
@@ -583,7 +583,7 @@ importers:
         specifier: ^2.3.0
         version: 2.3.0(react@18.2.0)
       '@pantheon-systems/pcc-react-sdk':
-        specifier: ~3.2.1
+        specifier: ~3.3.0
         version: link:../../packages/react-sdk
       autoprefixer:
         specifier: ^10.4.17
@@ -623,7 +623,7 @@ importers:
         specifier: ^2.3.0
         version: 2.3.0(react@18.2.0)
       '@pantheon-systems/pcc-react-sdk':
-        specifier: ~3.2.1
+        specifier: ~3.3.0
         version: link:../../packages/react-sdk
       autoprefixer:
         specifier: ^10.4.17
@@ -663,7 +663,7 @@ importers:
         specifier: 1.7.2
         version: 1.7.2(next@13.5.1)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.4.1)
       '@pantheon-systems/pcc-react-sdk':
-        specifier: ~3.2.1
+        specifier: ~3.3.0
         version: link:../../packages/react-sdk
       '@tailwindcss/typography':
         specifier: ^0.5.10
@@ -742,7 +742,7 @@ importers:
         specifier: 1.7.2
         version: 1.7.2(next@13.5.1)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.4.1)
       '@pantheon-systems/pcc-react-sdk':
-        specifier: ~3.2.1
+        specifier: ~3.3.0
         version: link:../../packages/react-sdk
       '@tailwindcss/typography':
         specifier: ^0.5.10
@@ -824,7 +824,7 @@ importers:
   starters/vue-starter:
     dependencies:
       '@pantheon-systems/pcc-vue-sdk':
-        specifier: ~3.2.0
+        specifier: ~3.3.0
         version: link:../../packages/vue-sdk
     devDependencies:
       '@nuxt/devtools':
@@ -858,7 +858,7 @@ importers:
   starters/vue-starter-ts:
     dependencies:
       '@pantheon-systems/pcc-vue-sdk':
-        specifier: ~3.2.0
+        specifier: ~3.3.0
         version: link:../../packages/vue-sdk
     devDependencies:
       '@nuxt/devtools':

--- a/starters/gatsby-starter-ts/package.json
+++ b/starters/gatsby-starter-ts/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@mdx-js/react": "^2.3.0",
-    "@pantheon-systems/pcc-react-sdk": "~3.2.1",
+    "@pantheon-systems/pcc-react-sdk": "~3.3.0",
     "autoprefixer": "^10.4.17",
     "gatsby": "^5.13.3",
     "gatsby-plugin-mdx": "^5.13.1",

--- a/starters/gatsby-starter/package.json
+++ b/starters/gatsby-starter/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@mdx-js/react": "^2.3.0",
-    "@pantheon-systems/pcc-react-sdk": "~3.2.1",
+    "@pantheon-systems/pcc-react-sdk": "~3.3.0",
     "autoprefixer": "^10.4.17",
     "gatsby": "^5.13.3",
     "gatsby-plugin-mdx": "^5.13.1",

--- a/starters/nextjs-starter-ts/package.json
+++ b/starters/nextjs-starter-ts/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@pantheon-systems/nextjs-kit": "1.7.2",
-    "@pantheon-systems/pcc-react-sdk": "~3.2.1",
+    "@pantheon-systems/pcc-react-sdk": "~3.3.0",
     "@tailwindcss/typography": "^0.5.10",
     "classnames": "^2.5.1",
     "dotenv": "^16.4.5",

--- a/starters/nextjs-starter/package.json
+++ b/starters/nextjs-starter/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@pantheon-systems/nextjs-kit": "1.7.2",
-    "@pantheon-systems/pcc-react-sdk": "~3.2.1",
+    "@pantheon-systems/pcc-react-sdk": "~3.3.0",
     "@tailwindcss/typography": "^0.5.10",
     "classnames": "^2.5.1",
     "dotenv": "^16.4.5",

--- a/starters/vue-starter-ts/CHANGELOG.md
+++ b/starters/vue-starter-ts/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @pantheon-systems/vue-pcc-starter-ts
+
+## null
+
+### Patch Changes
+
+- Updated dependencies [24be191]
+  - @pantheon-systems/pcc-vue-sdk@3.3.0

--- a/starters/vue-starter-ts/package.json
+++ b/starters/vue-starter-ts/package.json
@@ -21,6 +21,7 @@
     "vue-router": "^4.3.0"
   },
   "dependencies": {
-    "@pantheon-systems/pcc-vue-sdk": "~3.2.0"
-  }
+    "@pantheon-systems/pcc-vue-sdk": "~3.3.0"
+  },
+  "version": null
 }

--- a/starters/vue-starter/CHANGELOG.md
+++ b/starters/vue-starter/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @pantheon-systems/vue-pcc-starter
+
+## null
+
+### Patch Changes
+
+- Updated dependencies [24be191]
+  - @pantheon-systems/pcc-vue-sdk@3.3.0

--- a/starters/vue-starter/package.json
+++ b/starters/vue-starter/package.json
@@ -21,6 +21,7 @@
     "vue-router": "^4.3.0"
   },
   "dependencies": {
-    "@pantheon-systems/pcc-vue-sdk": "~3.2.0"
-  }
+    "@pantheon-systems/pcc-vue-sdk": "~3.3.0"
+  },
+  "version": null
 }


### PR DESCRIPTION
- CLI supports preview with locally running site as target
- Fixed various issues in starter kits
- Automagically combine empty spans and incorrectly exported ul/ol HTML format that Google generates
- Improved metadata filtering for GQL requests
- Added ability for developers to switch to new title rendering strategy (which is to not alter the document’s structure)