### PR TITLE
[PCC-1211] Fix cookie overriding in PantheonAPI

### DIFF
--- a/packages/vue-sdk/src/platforms/nuxt.ts
+++ b/packages/vue-sdk/src/platforms/nuxt.ts
@@ -9,6 +9,7 @@ import {
   getRouterParams,
   sendRedirect,
   setResponseHeader,
+  getResponseHeader,
 } from "h3";
 
 export function NuxtPantheonAPI(options?: PantheonAPIOptions) {
@@ -27,6 +28,9 @@ export function NuxtPantheonAPI(options?: PantheonAPIOptions) {
         },
         json: (data) => {
           return data;
+        },
+        getHeader: (key) => {
+          return getResponseHeader(event, key);
         },
       },
     );


### PR DESCRIPTION
# Issue
When `PantheonAPI` is called on a response object, it removes all existing cookies in that response when setting its own. This makes chaining `PantheonAPI` with other cookie-setting workflows impossible. 

# Changes
This PR updates the way PantheonAPI sets cookies such that cookies set on the response object prior to it being called are also included in the response instead of being disregarded. 