### PR TITLE
Bugfix: Updated GraphQL Client config so exceptions is thrown for the query errors

### DIFF
--- a/packages/core/src/core/pantheon-client.ts
+++ b/packages/core/src/core/pantheon-client.ts
@@ -154,13 +154,6 @@ export class PantheonClient {
       defaultOptions: {
         query: {
           fetchPolicy: "no-cache",
-          errorPolicy: "all",
-        },
-        watchQuery: {
-          errorPolicy: "all",
-        },
-        mutate: {
-          errorPolicy: "all",
         },
       },
     });


### PR DESCRIPTION
With `errorPolicy` set to `all`, `apolloClient.query` doesn't throw expected exceptions for GraphQL errors.
Ref: https://www.apollographql.com/docs/react/v2/data/error-handling/#error-policies

As a result of which `undefined` is returned by the called method and `handleApolloError` method is also not called.