### PR TITLE
removing gatsby stackblitz links and adding next-approuter link

### DIFF
--- a/starters/gatsby-starter-ts/README.md
+++ b/starters/gatsby-starter-ts/README.md
@@ -18,8 +18,6 @@ our docs site.
 
 ## Deploy your own
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/fork/github/pantheon-systems/pantheon-content-cloud-sdk/tree/main/starters/gatsby-starter-ts)
-
 For a quick start on your local machine, follow the instructions below:
 
 1. In your terminal, run the following command:

--- a/starters/gatsby-starter/README.md
+++ b/starters/gatsby-starter/README.md
@@ -18,8 +18,6 @@ our docs site.
 
 ## Deploy your own
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/fork/github/pantheon-systems/pantheon-content-cloud-sdk/tree/main/starters/gatsby-starter)
-
 For a quick start on your local machine, follow the instructions below:
 
 1. In your terminal, run the following command:

--- a/starters/nextjs-starter-approuter-ts/README.md
+++ b/starters/nextjs-starter-approuter-ts/README.md
@@ -9,7 +9,11 @@ we have created). Full documentation for this npm package based on
 [here](https://www.npmjs.com/package/@pantheon-systems/pcc) on
 our docs site.
 
-For a quick start, follow the instructions below:
+## Deploy your own
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/fork/github/pantheon-systems/pantheon-content-cloud-sdk/tree/main/starters/nextjs-starter-approuter-ts)
+
+For a quick start on your local machine, follow the instructions below:
 
 1. In your terminal, run the following commands:
 


### PR DESCRIPTION
Added notice of gatsby not. being supported by stackblitz to https://pcc.pantheon.io/docs/deploying-pcc-to-stackblitz