### PR TITLE
Bump to 3.5.0

### DIFF
--- a/.changeset/clever-pears-reflect.md
+++ b/.changeset/clever-pears-reflect.md
@@ -1,5 +1,0 @@
----
-"@pantheon-systems/pcc-sdk-core": patch
----
-
-Add textarea to supported smartcomponent metadata fields

--- a/.changeset/loud-students-pretend.md
+++ b/.changeset/loud-students-pretend.md
@@ -1,7 +1,0 @@
----
-"@pantheon-systems/pcc-react-sdk": minor
-"@pantheon-systems/pcc-vue-sdk": minor
----
-
-disableAllStyles is no longer applied to functional component overrides given in
-componentMap to ArticleRenderer

--- a/.changeset/strong-drinks-learn.md
+++ b/.changeset/strong-drinks-learn.md
@@ -1,6 +1,0 @@
----
-"@pantheon-systems/pcc-sdk-core": patch
----
-
-Fix how JSON was returned, headers were set, and redirect codes were checked for PantheonAPI affecting Nextjs page router
-implementations.

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pantheon-systems/pcc-browser-sdk
 
+## 3.5.0
+
+### Patch Changes
+
+- Updated dependencies [0e74720]
+- Updated dependencies [4cab3e2]
+  - @pantheon-systems/pcc-sdk-core@3.5.0
+
 ## 3.4.1
 
 ### Patch Changes

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -2,7 +2,7 @@
   "name": "@pantheon-systems/pcc-browser-sdk",
   "author": "@pantheon-systems",
   "description": "Pantheon Content Cloud Browser SDK",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "main": "dist/index.js",
   "files": [
     "dist",
@@ -21,6 +21,6 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@pantheon-systems/pcc-sdk-core": "^3.4.1"
+    "@pantheon-systems/pcc-sdk-core": "^3.5.0"
   }
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pantheon-systems/pcc-cli
 
+## 3.5.0
+
+### Patch Changes
+
+- Updated dependencies [0e74720]
+- Updated dependencies [4cab3e2]
+  - @pantheon-systems/pcc-sdk-core@3.5.0
+
 ## 3.4.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,7 @@
   "name": "@pantheon-systems/pcc-cli",
   "author": "@pantheon-systems",
   "description": "Pantheon Content Cloud CLI",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "type": "module",
   "license": "MIT",
   "keywords": [
@@ -37,7 +37,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@pantheon-systems/pcc-sdk-core": "~3.4.1",
+    "@pantheon-systems/pcc-sdk-core": "~3.5.0",
     "axios": "^1.6.8",
     "bluebird": "^3.7.2",
     "boxen": "^7.1.1",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pantheon-systems/pcc-sdk-core
 
+## 3.5.0
+
+### Patch Changes
+
+- 0e74720: Add textarea to supported smartcomponent metadata fields
+- 4cab3e2: Fix how JSON was returned, headers were set, and redirect codes were
+  checked for PantheonAPI affecting Nextjs page router implementations.
+
 ## 3.4.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "@pantheon-systems/pcc-sdk-core",
   "author": "@pantheon-systems",
   "description": "Pantheon Content Cloud SDK Core",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react-sample-library/CHANGELOG.md
+++ b/packages/react-sample-library/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @pantheon-systems/pcc-vue-sdk
 
+## 3.5.0
+
+### Patch Changes
+
+- Updated dependencies [0e74720]
+- Updated dependencies [8ff023b]
+- Updated dependencies [4cab3e2]
+  - @pantheon-systems/pcc-sdk-core@3.5.0
+  - @pantheon-systems/pcc-react-sdk@3.5.0
+
 ## 3.4.1
 
 ### Patch Changes

--- a/packages/react-sample-library/package.json
+++ b/packages/react-sample-library/package.json
@@ -2,7 +2,7 @@
   "name": "@pantheon-systems/pcc-react-sample-library",
   "author": "@pantheon-systems",
   "description": "Pantheon Content Cloud Sample Component Library for React",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -68,8 +68,8 @@
     }
   },
   "dependencies": {
-    "@pantheon-systems/pcc-react-sdk": "~3.4.1",
-    "@pantheon-systems/pcc-sdk-core": "~3.4.1",
+    "@pantheon-systems/pcc-react-sdk": "~3.5.0",
+    "@pantheon-systems/pcc-sdk-core": "~3.5.0",
     "@pantheon-systems/pds-toolkit-react": "1.0.0-dev.55"
   },
   "sideEffects": false

--- a/packages/react-sdk/CHANGELOG.md
+++ b/packages/react-sdk/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @pantheon-systems/pcc-react-sdk
 
+## 3.5.0
+
+### Minor Changes
+
+- 8ff023b: disableAllStyles is no longer applied to functional component
+  overrides given in componentMap to ArticleRenderer
+
+### Patch Changes
+
+- Updated dependencies [0e74720]
+- Updated dependencies [4cab3e2]
+  - @pantheon-systems/pcc-sdk-core@3.5.0
+
 ## 3.4.1
 
 ### Patch Changes

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -2,7 +2,7 @@
   "name": "@pantheon-systems/pcc-react-sdk",
   "author": "@pantheon-systems",
   "description": "Pantheon Content Cloud React SDK",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "license": "MIT",
   "keywords": [
     "pcc",
@@ -94,7 +94,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.9.5",
-    "@pantheon-systems/pcc-sdk-core": "~3.4.1",
+    "@pantheon-systems/pcc-sdk-core": "~3.5.0",
     "framer-motion": "^10.18.0",
     "goober": "^2.1.14",
     "graphql": "^16.8.1",

--- a/packages/vue-sdk/CHANGELOG.md
+++ b/packages/vue-sdk/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @pantheon-systems/pcc-vue-sdk
 
+## 3.5.0
+
+### Minor Changes
+
+- 8ff023b: disableAllStyles is no longer applied to functional component
+  overrides given in componentMap to ArticleRenderer
+
+### Patch Changes
+
+- Updated dependencies [0e74720]
+- Updated dependencies [4cab3e2]
+  - @pantheon-systems/pcc-sdk-core@3.5.0
+
 ## 3.4.1
 
 ### Patch Changes

--- a/packages/vue-sdk/package.json
+++ b/packages/vue-sdk/package.json
@@ -2,7 +2,7 @@
   "name": "@pantheon-systems/pcc-vue-sdk",
   "author": "@pantheon-systems",
   "description": "Pantheon Content Cloud Vue SDK",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -81,7 +81,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.9.5",
-    "@pantheon-systems/pcc-sdk-core": "~3.4.1",
+    "@pantheon-systems/pcc-sdk-core": "~3.5.0",
     "@vue/apollo-composable": "4.0.0-beta.12",
     "floating-vue": "2.0.0-beta.24",
     "graphql": "^16.8.1",

--- a/starters/gatsby-starter-ts/package.json
+++ b/starters/gatsby-starter-ts/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@mdx-js/react": "^2.3.0",
-    "@pantheon-systems/pcc-react-sdk": "~3.4.1",
+    "@pantheon-systems/pcc-react-sdk": "~3.5.0",
     "@pantheon-systems/pds-toolkit-react": "1.0.0-dev.55",
     "autoprefixer": "^10.4.17",
     "gatsby": "^5.13.3",

--- a/starters/gatsby-starter/package.json
+++ b/starters/gatsby-starter/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@mdx-js/react": "^2.3.0",
-    "@pantheon-systems/pcc-react-sdk": "~3.4.1",
+    "@pantheon-systems/pcc-react-sdk": "~3.5.0",
     "@pantheon-systems/pds-toolkit-react": "1.0.0-dev.55",
     "autoprefixer": "^10.4.17",
     "gatsby": "^5.13.3",

--- a/starters/nextjs-starter-ts/package.json
+++ b/starters/nextjs-starter-ts/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@pantheon-systems/nextjs-kit": "1.7.2",
-    "@pantheon-systems/pcc-react-sdk": "~3.4.1",
+    "@pantheon-systems/pcc-react-sdk": "~3.5.0",
     "@pantheon-systems/pds-toolkit-react": "1.0.0-dev.55",
     "@tailwindcss/typography": "^0.5.10",
     "classnames": "^2.5.1",

--- a/starters/nextjs-starter/package.json
+++ b/starters/nextjs-starter/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@pantheon-systems/nextjs-kit": "1.7.2",
-    "@pantheon-systems/pcc-react-sdk": "~3.4.1",
+    "@pantheon-systems/pcc-react-sdk": "~3.5.0",
     "@pantheon-systems/pds-toolkit-react": "1.0.0-dev.55",
     "@tailwindcss/typography": "^0.5.10",
     "classnames": "^2.5.1",

--- a/starters/vue-starter-ts/CHANGELOG.md
+++ b/starters/vue-starter-ts/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Patch Changes
 
+- Updated dependencies [8ff023b]
+  - @pantheon-systems/pcc-vue-sdk@3.5.0
+
+## null
+
+### Patch Changes
+
 - Updated dependencies [37e1c39]
   - @pantheon-systems/pcc-vue-sdk@3.4.0
 

--- a/starters/vue-starter-ts/package.json
+++ b/starters/vue-starter-ts/package.json
@@ -21,7 +21,7 @@
     "vue-router": "^4.3.0"
   },
   "dependencies": {
-    "@pantheon-systems/pcc-vue-sdk": "~3.4.0"
+    "@pantheon-systems/pcc-vue-sdk": "~3.5.0"
   },
   "version": null
 }

--- a/starters/vue-starter/CHANGELOG.md
+++ b/starters/vue-starter/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Patch Changes
 
+- Updated dependencies [8ff023b]
+  - @pantheon-systems/pcc-vue-sdk@3.5.0
+
+## null
+
+### Patch Changes
+
 - Updated dependencies [37e1c39]
   - @pantheon-systems/pcc-vue-sdk@3.4.0
 

--- a/starters/vue-starter/package.json
+++ b/starters/vue-starter/package.json
@@ -21,7 +21,7 @@
     "vue-router": "^4.3.0"
   },
   "dependencies": {
-    "@pantheon-systems/pcc-vue-sdk": "~3.4.0"
+    "@pantheon-systems/pcc-vue-sdk": "~3.5.0"
   },
   "version": null
 }


### PR DESCRIPTION
- 0e74720: Add textarea to supported smartcomponent metadata fields
- 4cab3e2: Fix how JSON was returned, headers were set, and redirect codes were checked for PantheonAPI affecting Nextjs page router implementations.