### PR TITLE
Fix how protocol is determined in redirects with forwarded hosts

### DIFF
--- a/packages/cli/src/cli/commands/init.ts
+++ b/packages/cli/src/cli/commands/init.ts
@@ -143,8 +143,8 @@ const init = async ({
     template === "gatsby"
       ? ".env.development"
       : template === "vue"
-      ? ".env"
-      : ".env.local";
+        ? ".env"
+        : ".env.local";
 
   copyFileSync(
     path.join(absoluteProjectPath, ".env.example"),
@@ -181,7 +181,7 @@ const init = async ({
           await inquirer.prompt({
             type: "list",
             name: "siteId",
-            choices: (await AddOnApiHelper.listSites())
+            choices: (await AddOnApiHelper.listSites({}))
               .filter((x) => !x.__isPlayground)
               .map((x) => `${x.url} (${x.id})`),
           })

--- a/packages/core/src/core/pantheon-api.ts
+++ b/packages/core/src/core/pantheon-api.ts
@@ -199,8 +199,8 @@ export const PantheonAPI = (givenOptions?: PantheonAPIOptions) => {
     const command = Array.isArray(commandInput)
       ? commandInput
       : typeof commandInput === "string"
-      ? commandInput.split("/")
-      : [commandInput];
+        ? commandInput.split("/")
+        : [commandInput];
 
     if (pccGrant) {
       setCookie(headers, `PCC-GRANT=${pccGrant}; Path=/; SameSite=Lax`);
@@ -397,8 +397,8 @@ function setCookie(headers: Headers, value: string) {
       ...(typeof previous === "string"
         ? [previous]
         : Array.isArray(previous)
-        ? previous
-        : []),
+          ? previous
+          : []),
       value,
     ].join("; "),
   );

--- a/packages/core/src/core/pantheon-api.ts
+++ b/packages/core/src/core/pantheon-api.ts
@@ -128,9 +128,8 @@ function generateBaseURL(req: ApiRequest) {
     // If this is a forwarded request, use the protocol and host from the headers.
     if (req.headers?.["x-forwarded-host"]) {
       return `${
-        req.headers["x-forwarded-proto"] || req.connection?.encrypted
-          ? "https"
-          : "http"
+        req.headers["x-forwarded-proto"] ||
+        (req.connection?.encrypted ? "https" : "http")
       }://${req.headers["x-forwarded-host"]}`;
     }
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -193,25 +193,25 @@ type InferFieldProps<T extends SmartComponentMapField> = T extends {
   ? O extends readonly { value: infer V }[]
     ? V
     : O extends readonly string[]
-    ? O[number]
-    : unknown
+      ? O[number]
+      : unknown
   : T extends { type: "number" }
-  ? number
-  : T extends { type: "boolean" }
-  ? boolean
-  : T extends { type: "string" | "file" | "date" }
-  ? string
-  : T extends {
-      type: "object";
-      fields: Record<string, unknown>;
-    }
-  ? T["multiple"] extends true
-    ? Optional<
-        { [K in keyof T["fields"]]: InferFieldProps<T["fields"][K]> },
-        OptionalFields<T["fields"]>
-      >[]
-    : Optional<
-        { [K in keyof T["fields"]]: InferFieldProps<T["fields"][K]> },
-        OptionalFields<T["fields"]>
-      >
-  : unknown;
+    ? number
+    : T extends { type: "boolean" }
+      ? boolean
+      : T extends { type: "string" | "file" | "date" }
+        ? string
+        : T extends {
+              type: "object";
+              fields: Record<string, unknown>;
+            }
+          ? T["multiple"] extends true
+            ? Optional<
+                { [K in keyof T["fields"]]: InferFieldProps<T["fields"][K]> },
+                OptionalFields<T["fields"]>
+              >[]
+            : Optional<
+                { [K in keyof T["fields"]]: InferFieldProps<T["fields"][K]> },
+                OptionalFields<T["fields"]>
+              >
+          : unknown;


### PR DESCRIPTION
# Issue
The check in the diff would evaluate to true and return "https" instead of returning the value of `x-forwarded-proto`