### PR TITLE
[PCC-1388] Add methods for fetching site data

### DIFF
--- a/.changeset/four-beers-draw.md
+++ b/.changeset/four-beers-draw.md
@@ -1,0 +1,6 @@
+---
+"@pantheon-systems/pcc-react-sdk": patch
+"@pantheon-systems/pcc-vue-sdk": patch
+---
+
+GraphQL queries and query hooks are now exposed for custom usage

--- a/.changeset/tender-poets-sit.md
+++ b/.changeset/tender-poets-sit.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/pcc-sdk-core": patch
+---
+
+Added queries and helper methods for fetching site information

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Patch Changes
 
 - 3651708: Fix how protocols are being forwarded by API handler.
-- 61363af: Removes inline sourcemaps. Sourcemaps are still provided, just linked in separate files instead.
+- 61363af: Removes inline sourcemaps. Sourcemaps are still provided, just linked
+  in separate files instead.
 - Updated dependencies [61363af]
 - Updated dependencies [3651708]
 - Updated dependencies [61363af]

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 ### Patch Changes
 
-- 61363af: Fixes issue where redirects to local preview/publish targets would be redirected to https://localhost
+- 61363af: Fixes issue where redirects to local preview/publish targets would be
+  redirected to https://localhost
 - 3651708: Fix how protocols are being forwarded by API handler.
-- 61363af: Removes inline sourcemaps. Sourcemaps are still provided, just linked in separate files instead.
+- 61363af: Removes inline sourcemaps. Sourcemaps are still provided, just linked
+  in separate files instead.
 
 ## 3.6.0-beta.3
 

--- a/packages/core/src/helpers/convenience.ts
+++ b/packages/core/src/helpers/convenience.ts
@@ -11,6 +11,7 @@ import {
   getArticlesWithSummary,
 } from "./articles";
 import { getAllTags } from "./metadata";
+import { getSite as _getSite } from "./site";
 
 const config = {
   // eslint-disable-next-line turbo/no-undeclared-env-vars
@@ -141,6 +142,13 @@ async function getRecommendedArticles(id: number | string) {
   return article.data.recommendedArticles as Article[];
 }
 
+async function getSite() {
+  const client = buildPantheonClient({ isClientSide: false });
+  const site = await _getSite(client, client.siteId);
+
+  return site;
+}
+
 export const PCCConvenienceFunctions = {
   buildPantheonClient,
   getAllArticles,
@@ -149,4 +157,5 @@ export const PCCConvenienceFunctions = {
   getRecommendedArticles,
   getPaginatedArticles,
   getTags,
+  getSite,
 };

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -3,3 +3,4 @@ export * from "./convenience";
 export * from "./errors";
 export * from "./metadata";
 export * from "./validator";
+export * from "./site";

--- a/packages/core/src/helpers/site.ts
+++ b/packages/core/src/helpers/site.ts
@@ -1,0 +1,14 @@
+import { PantheonClient } from "../core/pantheon-client";
+import { GET_SITE_QUERY } from "../lib/gql";
+import { Site } from "../types";
+
+export async function getSite(client: PantheonClient, id: string) {
+  const site = await client.apolloClient.query({
+    query: GET_SITE_QUERY,
+    variables: {
+      id,
+    },
+  });
+
+  return site.data.site as Site;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export * from "./core/pantheon-api";
 
 export * from "./lib/apollo-client";
 export * from "./lib/gql";
+export * as GQL from "./lib/gql";
 export * from "./lib/jwt";
 
 export * from "./helpers";

--- a/packages/core/src/lib/gql.ts
+++ b/packages/core/src/lib/gql.ts
@@ -204,3 +204,17 @@ export const GET_RECOMMENDED_ARTICLES_QUERY = gql`
     }
   }
 `;
+
+export const GET_SITE_QUERY = gql`
+  query GetSite($id: String!) {
+    site(id: $id) {
+      id
+      name
+      url
+      domain
+      contentStructure
+      tags
+      metadataFields
+    }
+  }
+`;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -48,6 +48,16 @@ export enum SortOrder {
   DESC = "DESC",
 }
 
+export interface Site {
+  id: string;
+  name: string;
+  url: string;
+  domain: string;
+  tags: string[];
+  contentStructure: Record<string, unknown>;
+  metadataFields: Record<string, unknown>;
+}
+
 export interface TreePantheonContent {
   tag: string;
   attrs: {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -54,7 +54,7 @@ export interface Site {
   url: string;
   domain: string;
   tags: string[];
-  contentStructure: Record<string, unknown>;
+  contentStructure: Record<string, unknown> | null;
   metadataFields: Record<string, unknown>;
 }
 

--- a/packages/react-sdk/CHANGELOG.md
+++ b/packages/react-sdk/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 - 80ef092: Update preview bar copy and icons
 - 4ed0c05: Don't export pantheon-context in server export.
-- 61363af: Removes inline sourcemaps. Sourcemaps are still provided, just linked in separate files instead.
+- 61363af: Removes inline sourcemaps. Sourcemaps are still provided, just linked
+  in separate files instead.
 - 4ed0c05: Export pantheon-content from root entry point.
 - 14a968b: Make preview bar sticky at the top by default
 - Updated dependencies [61363af]

--- a/packages/react-sdk/src/hooks/index.ts
+++ b/packages/react-sdk/src/hooks/index.ts
@@ -1,3 +1,7 @@
 export { useArticle } from "./use-article";
 export { useArticles } from "./use-articles";
 export { usePagination } from "./use-pagination";
+
+export { useQuery } from "@apollo/client/react/hooks/useQuery.js";
+export { useMutation } from "@apollo/client/react/hooks/useMutation.js";
+export { useSubscription } from "@apollo/client/react/hooks/useSubscription.js";

--- a/packages/react-sdk/src/server/index.ts
+++ b/packages/react-sdk/src/server/index.ts
@@ -13,6 +13,8 @@ export {
   getArticleBySlugOrId,
   PCCConvenienceFunctions,
   updateConfig,
+  GQL,
+  getSite,
 } from "@pantheon-systems/pcc-sdk-core";
 export * from "@pantheon-systems/pcc-sdk-core/types";
 

--- a/packages/vue-sdk/src/hooks/index.ts
+++ b/packages/vue-sdk/src/hooks/index.ts
@@ -1,2 +1,4 @@
 export { useArticle } from "./use-article";
 export { useArticles } from "./use-articles";
+
+export { useQuery } from "@vue/apollo-composable";


### PR DESCRIPTION
# Overview
Adds the GraphQL query and helper methods for fetching a site's data to the packages

# Changes
- Adds site resource GraphQL query and helper `getSiteMethods`
- Exposes Apollo query hooks for use outside our defined helper methods
- Exports our GQL queries so they can be extended by users as necessary 