### PR TITLE
[PCC-1210] Add support for setting preferred webhook events

### DIFF
--- a/packages/cli/src/cli/commands/sites/webhooks.ts
+++ b/packages/cli/src/cli/commands/sites/webhooks.ts
@@ -1,0 +1,38 @@
+import inquirer from "inquirer";
+import ora from "ora";
+import AddOnApiHelper from "../../../lib/addonApiHelper";
+import { errorHandler } from "../../exceptions";
+
+async function configurePreferredWebhookEvents(siteId: string) {
+  // Fetch available events
+  const availableEventsSpinner = ora("Fetching available events...").start();
+  const availableEvents =
+    await AddOnApiHelper.fetchAvailableWebhookEvents(siteId);
+  availableEventsSpinner.succeed("Fetched available events");
+
+  // Prompt user to select events
+  const { selectedEvents } = await inquirer.prompt([
+    {
+      type: "checkbox",
+      name: "selectedEvents",
+      message:
+        "Select events to receive notifications for. Select none to receive notifications for all events.",
+      choices: availableEvents,
+    },
+  ]);
+
+  if (selectedEvents.length === 0) {
+    console.info(
+      "No events selected. Your webhook will receive notifications for all events.",
+    );
+  }
+
+  // Update events for the site
+  const updateEventsSpinner = ora("Updating preferred events...").start();
+  await AddOnApiHelper.updateSiteConfig(siteId, {
+    preferredEvents: selectedEvents,
+  });
+  updateEventsSpinner.succeed("Updated preferred events");
+}
+
+export default errorHandler(configurePreferredWebhookEvents);

--- a/packages/cli/src/cli/exceptions.ts
+++ b/packages/cli/src/cli/exceptions.ts
@@ -32,8 +32,8 @@ export function errorHandler<T>(
       if (cleanup) cleanup(arg);
 
       if (e instanceof UserNotLoggedIn) {
-        console.log(chalk.red("Error: User is not logged in."));
-        console.log(chalk.yellow('Please run "pcc login" to login.'));
+        console.log(chalk.red("\nError: User is not logged in."));
+        console.log(chalk.yellow('\nPlease run "pcc login" to login.'));
       } else {
         if (
           axios.isAxiosError(e) &&
@@ -41,7 +41,7 @@ export function errorHandler<T>(
           e.response?.data?.message
         ) {
           // Operational error
-          console.log(chalk.red(`Error: ${e.response.data.message}`));
+          console.log(chalk.red(`\nError: ${e.response.data.message}`));
         } else {
           // Unhandled error
           console.log(
@@ -49,7 +49,7 @@ export function errorHandler<T>(
           );
           console.log(
             chalk.red(
-              "Error: Something went wrong. Please contact Pantheon support team.",
+              "\nError: Something went wrong. Please contact Pantheon support team.",
             ),
           );
         }

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -34,6 +34,7 @@ import {
   SITE_EXAMPLES,
   updateSiteConfig,
 } from "./commands/sites/site";
+import configurePreferredWebhookEvents from "./commands/sites/webhooks";
 import {
   createToken,
   listTokens,
@@ -552,6 +553,19 @@ yargs(hideBin(process.argv))
                     id: args.id as string,
                     limit: args.limit as number,
                   }),
+              )
+              .command(
+                "preferred-events <id>",
+                "Set preferred webhook events for a given site. Your webhook will only receive notifications for events that you specify.",
+                (yargs) => {
+                  yargs.strictCommands().positional("<id>", {
+                    describe: "ID of the site for which you want to configure.",
+                    demandOption: true,
+                    type: "string",
+                  });
+                },
+                async (args) =>
+                  configurePreferredWebhookEvents(String(args.id)),
               );
           },
         )

--- a/packages/cli/src/lib/addonApiHelper.ts
+++ b/packages/cli/src/lib/addonApiHelper.ts
@@ -430,15 +430,17 @@ class AddOnApiHelper {
       url,
       webhookUrl,
       webhookSecret,
+      preferredEvents,
     }: {
       url?: string;
       webhookUrl?: string;
       webhookSecret?: string;
+      preferredEvents?: string[];
     },
   ): Promise<void> {
     const idToken = await this.getIdToken();
 
-    const configuredWebhook = webhookUrl || webhookSecret;
+    const configuredWebhook = webhookUrl || webhookSecret || preferredEvents;
 
     await axios.patch(
       `${(await getApiConfig()).SITE_ENDPOINT}/${id}`,
@@ -448,6 +450,7 @@ class AddOnApiHelper {
           webhookConfig: {
             ...(webhookUrl && { webhookUrl: webhookUrl }),
             ...(webhookSecret && { webhookSecret: webhookSecret }),
+            ...(preferredEvents && { preferredEvents }),
           },
         }),
       },
@@ -485,6 +488,21 @@ class AddOnApiHelper {
     );
 
     return resp.data as WebhookDeliveryLog[];
+  }
+
+  static async fetchAvailableWebhookEvents(siteId: string) {
+    const idToken = await this.getIdToken();
+
+    const resp = await axios.get(
+      `${(await getApiConfig()).SITE_ENDPOINT}/${siteId}/availableWebhookEvents`,
+      {
+        headers: {
+          Authorization: `Bearer ${idToken}`,
+        },
+      },
+    );
+
+    return resp.data as string[];
   }
 }
 


### PR DESCRIPTION
# Overview
Adds support for setting preferred webhook events for a site. 

# Screenshots
![Screenshot 2024-06-24 at 09 28 13](https://github.com/pantheon-systems/pantheon-content-cloud-sdk/assets/87580113/60f8ebf2-e24a-438f-93ab-19dc434e980f)
![Screenshot 2024-06-24 at 09 28 27](https://github.com/pantheon-systems/pantheon-content-cloud-sdk/assets/87580113/36435fa1-fa95-41d5-88b4-d89d8015c700)

# Other Changes
- Updates `errorHandler` to always show error messages on a newline