### PR TITLE
Fix delete site command name and success message. More flexible error messages from backend.

### DIFF
--- a/packages/cli/src/cli/commands/sites/site.ts
+++ b/packages/cli/src/cli/commands/sites/site.ts
@@ -25,8 +25,8 @@ export const deleteSite = errorHandler<{
 }>(async ({ id, transferToSiteId, force }) => {
   const spinner = ora("Deleting site...").start();
   try {
-    const siteId = await AddOnApiHelper.deleteSite(id, transferToSiteId, force);
-    spinner.succeed(`Successfully deleted the site with id "${siteId}"`);
+    await AddOnApiHelper.deleteSite(id, transferToSiteId, force);
+    spinner.succeed(`Successfully deleted the site with id "${id}"`);
   } catch (e) {
     spinner.fail();
     throw e;

--- a/packages/cli/src/cli/exceptions.ts
+++ b/packages/cli/src/cli/exceptions.ts
@@ -38,10 +38,12 @@ export function errorHandler<T>(
         if (
           axios.isAxiosError(e) &&
           (e.response?.status ?? 500) < 500 && // Treat internal server errors as unhandled errors
-          e.response?.data?.message
+          e.response?.data
         ) {
           // Operational error
-          console.log(chalk.red(`\nError: ${e.response.data.message}`));
+          console.log(
+            chalk.red(`\nError: ${e.response.data.message || e.response.data}`),
+          );
         } else {
           // Unhandled error
           console.log(

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -381,7 +381,7 @@ yargs(hideBin(process.argv))
           async (args) => await createSite(args.url as string),
         )
         .command(
-          "create [options]",
+          "delete [options]",
           "Delete site.",
           (yargs) => {
             yargs.option("id", {


### PR DESCRIPTION
- Fix delete site command name and success message.
- Show endpoint error message even if it wasn't structured as JSON with a message property.