### PR TITLE
PCC-1144 Add CSS support for well-spaced images when they are wrapping text.

### DIFF
--- a/.changeset/full-crabs-jam.md
+++ b/.changeset/full-crabs-jam.md
@@ -1,0 +1,7 @@
+---
+"@pantheon-systems/pcc-react-sdk": minor
+---
+
+Image captions are now rendered by default, but can be opted out by using
+\_\_experimentalFlags.renderImageCpations in ArticleRenderer. Image containers
+and captions are now targetable with CSS classes.

--- a/packages/react-sdk/src/components/ArticleRenderer/PantheonTreeV2Renderer.tsx
+++ b/packages/react-sdk/src/components/ArticleRenderer/PantheonTreeV2Renderer.tsx
@@ -120,6 +120,7 @@ const PantheonTreeRenderer = ({
             justifyContent: "center",
             fontSize: ".75rem",
           }}
+          className="pantheon-caption"
         >
           {imageTitle}
         </span>,

--- a/packages/react-sdk/src/components/ArticleRenderer/PantheonTreeV2Renderer.tsx
+++ b/packages/react-sdk/src/components/ArticleRenderer/PantheonTreeV2Renderer.tsx
@@ -85,12 +85,31 @@ const PantheonTreeRenderer = ({
     (element.tag !== "img" || !preserveImageStyles) &&
     (typeof componentOverride === "string" || componentOverride == null);
 
+  let targetingClasses = [];
+  const styleObject = shouldPruneStyles
+    ? undefined
+    : getStyleObjectFromString(element?.style);
+
+  if (
+    element.tag === "span" &&
+    children.length === 1 &&
+    element.children[0].tag === "img"
+  ) {
+    targetingClasses.push("pantheon-img-container");
+
+    if (styleObject?.float === "left") {
+      targetingClasses.push("pantheon-img-container-breakleft");
+    } else if (styleObject?.float === "right") {
+      targetingClasses.push("pantheon-img-container-breakright");
+    } else {
+      targetingClasses.push("pantheon-img-container-inline");
+    }
+  }
+
   return React.createElement(
     componentOverride || convertedTagName,
     {
-      style: shouldPruneStyles
-        ? undefined
-        : getStyleObjectFromString(element?.style),
+      style: styleObject,
 
       // If shouldPruneStyles, then overwrite the class
       // but leave other attrs intact.
@@ -98,7 +117,11 @@ const PantheonTreeRenderer = ({
         Object.assign(
           {},
           element.attrs,
-          shouldPruneStyles ? { class: null } : {},
+          shouldPruneStyles
+            ? { class: targetingClasses.join(" ") }
+            : {
+                class: `${element.attrs.class || ""} ${targetingClasses.join(" ")}`,
+              },
         ),
       ),
     },

--- a/packages/react-sdk/src/components/ArticleRenderer/PantheonTreeV2Renderer.tsx
+++ b/packages/react-sdk/src/components/ArticleRenderer/PantheonTreeV2Renderer.tsx
@@ -12,6 +12,7 @@ interface Props {
   disableAllStyles?: boolean;
   preserveImageStyles?: boolean;
   disableDefaultErrorBoundaries?: boolean;
+  renderImageCaptions?: boolean;
 }
 
 const PantheonTreeRenderer = ({
@@ -21,6 +22,7 @@ const PantheonTreeRenderer = ({
   disableAllStyles,
   preserveImageStyles,
   disableDefaultErrorBoundaries,
+  renderImageCaptions,
 }: Props): React.ReactElement | null => {
   const children =
     element.children?.map((child, idx) =>
@@ -32,6 +34,7 @@ const PantheonTreeRenderer = ({
         disableAllStyles,
         preserveImageStyles,
         disableDefaultErrorBoundaries,
+        renderImageCaptions,
       }),
     ) ?? [];
 
@@ -103,6 +106,24 @@ const PantheonTreeRenderer = ({
       targetingClasses.push("pantheon-img-container-breakright");
     } else {
       targetingClasses.push("pantheon-img-container-inline");
+    }
+
+    const imageChild = element.children[0];
+    const imageTitle = imageChild.attrs?.title?.trim();
+
+    if (renderImageCaptions !== false && imageTitle?.length) {
+      nodeChildren.push(
+        <span
+          style={{
+            width: "100%",
+            display: "flex",
+            justifyContent: "center",
+            fontSize: ".75rem",
+          }}
+        >
+          {imageTitle}
+        </span>,
+      );
     }
   }
 

--- a/packages/react-sdk/src/components/ArticleRenderer/PantheonTreeV2Renderer.tsx
+++ b/packages/react-sdk/src/components/ArticleRenderer/PantheonTreeV2Renderer.tsx
@@ -88,7 +88,7 @@ const PantheonTreeRenderer = ({
     (element.tag !== "img" || !preserveImageStyles) &&
     (typeof componentOverride === "string" || componentOverride == null);
 
-  let targetingClasses = [];
+  const targetingClasses = [];
   const styleObject = shouldPruneStyles
     ? undefined
     : getStyleObjectFromString(element?.style);

--- a/packages/react-sdk/src/components/ArticleRenderer/index.tsx
+++ b/packages/react-sdk/src/components/ArticleRenderer/index.tsx
@@ -57,6 +57,7 @@ interface Props {
     preserveImageStyles?: boolean;
     disableDefaultErrorBoundaries?: boolean;
     useUnintrusiveTitleRendering?: boolean;
+    renderImageCaptions?: boolean;
   };
 }
 
@@ -139,6 +140,7 @@ const ArticleRenderer = ({
       preserveImageStyles: !!__experimentalFlags?.preserveImageStyles,
       disableDefaultErrorBoundaries:
         !!__experimentalFlags?.disableDefaultErrorBoundaries,
+      renderImageCaptions: __experimentalFlags?.renderImageCaptions !== false,
     });
   }
 
@@ -155,6 +157,8 @@ const ArticleRenderer = ({
           preserveImageStyles: !!__experimentalFlags?.preserveImageStyles,
           disableDefaultErrorBoundaries:
             !!__experimentalFlags?.disableDefaultErrorBoundaries,
+          renderImageCaptions:
+            __experimentalFlags?.renderImageCaptions !== false,
         }),
       )}
     </div>

--- a/packages/vue-sdk/src/components/Renderer/index.ts
+++ b/packages/vue-sdk/src/components/Renderer/index.ts
@@ -46,6 +46,7 @@ export type ExperimentalFlags = {
   preserveImageStyles?: boolean;
   disableDefaultErrorBoundaries: boolean;
   useUnintrusiveTitleRendering?: boolean;
+  renderImageCaptions?: boolean;
 };
 
 const pccGeneratedPortalTargetKey = "__pcc-portal-target__";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ overrides:
   axios: 1.8.2
   image-size: 1.2.1
 
-pnpmfileChecksum: sha256-4MsH1g26NkA4ElRATPgUw4yyCde2YSF6pkEsB+NKNFM=
+pnpmfileChecksum: dwsml3ncnigkmiwvwlkoqsfuki
 
 importers:
 

--- a/starters/nextjs-starter-approuter-ts/styles/globals.css
+++ b/starters/nextjs-starter-approuter-ts/styles/globals.css
@@ -32,8 +32,9 @@
 /* Inline images should be horizontally centered. */
 .pantheon-img-container-inline {
   max-width: 100% !important;
-  display: flex;
-  justify-content: center;
+  justify-items: center;
+  flex-direction: column;
+  align-items: center;
 }
 
 /* 

--- a/starters/nextjs-starter-approuter-ts/styles/globals.css
+++ b/starters/nextjs-starter-approuter-ts/styles/globals.css
@@ -17,16 +17,23 @@
 }
 
 /* Handle margins and left/right padding for images, to support text wrapping. */
-.prose :where(img):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+.pantheon-img-container img {
   margin: 0;
 }
 
-.prose span[style*="shape-outside"][style*="float:left"] {
+.pantheon-img-container-breakleft {
   padding-right: 2em;
 }
 
-.prose span[style*="shape-outside"][style*="float:right"] {
+.pantheon-img-container-breakright {
   padding-left: 2em;
+}
+
+/* Inline images should be horizontally centered. */
+.pantheon-img-container-inline {
+  max-width: 100% !important;
+  display: flex;
+  justify-content: center;
 }
 
 /* 
@@ -34,6 +41,6 @@
   text-wrapped images, but at the cost of not being able
   to set vertical offset of a wrapped image in Google Docs.
 */
-.prose span[style*="shape-outside"] {
+.pantheon-img-container {
   margin: 2em 0;
 }

--- a/starters/nextjs-starter-approuter-ts/styles/globals.css
+++ b/starters/nextjs-starter-approuter-ts/styles/globals.css
@@ -15,3 +15,25 @@
     @apply absolute bottom-0 left-0 right-0 top-0 h-full w-full;
   }
 }
+
+/* Handle margins and left/right padding for images, to support text wrapping. */
+.prose :where(img):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  margin: 0;
+}
+
+.prose span[style*="shape-outside"][style*="float:left"] {
+  padding-right: 2em;
+}
+
+.prose span[style*="shape-outside"][style*="float:right"] {
+  padding-left: 2em;
+}
+
+/* 
+  This creates consistent spacing above and below
+  text-wrapped images, but at the cost of not being able
+  to set vertical offset of a wrapped image in Google Docs.
+*/
+.prose span[style*="shape-outside"] {
+  margin: 2em 0;
+}

--- a/starters/nextjs-starter-approuter-ts/styles/globals.css
+++ b/starters/nextjs-starter-approuter-ts/styles/globals.css
@@ -32,9 +32,8 @@
 /* Inline images should be horizontally centered. */
 .pantheon-img-container-inline {
   max-width: 100% !important;
-  justify-items: center;
+  place-items: center;
   flex-direction: column;
-  align-items: center;
 }
 
 /* 

--- a/starters/nextjs-starter-approuter-ts/styles/globals.css
+++ b/starters/nextjs-starter-approuter-ts/styles/globals.css
@@ -31,6 +31,7 @@
 
 /* Inline images should be horizontally centered. */
 .pantheon-img-container-inline {
+  display: flex;
   max-width: 100% !important;
   place-items: center;
   flex-direction: column;

--- a/starters/nextjs-starter-ts/styles/globals.css
+++ b/starters/nextjs-starter-ts/styles/globals.css
@@ -20,3 +20,26 @@ li::before {
     @apply absolute bottom-0 left-0 right-0 top-0 h-full w-full;
   }
 }
+
+/* Handle margins and left/right padding for images, to support text wrapping. */
+.prose :where(img):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  margin: 0;
+}
+
+.prose span[style*="shape-outside"][style*="float:left"] {
+  padding-right: 2em;
+}
+
+.prose span[style*="shape-outside"][style*="float:right"] {
+  padding-left: 2em;
+}
+
+/* 
+  This creates consistent spacing above and below
+  text-wrapped images, but at the cost of not being able
+  to set vertical offset of a wrapped image in Google Docs.
+*/
+.prose span[style*="shape-outside"] {
+  margin: 2em 0;
+}
+

--- a/starters/nextjs-starter-ts/styles/globals.css
+++ b/starters/nextjs-starter-ts/styles/globals.css
@@ -38,7 +38,9 @@ li::before {
 .pantheon-img-container-inline {
   max-width: 100% !important;
   display: flex;
-  justify-content: center;
+  justify-items: center;
+  flex-direction: column;
+  align-items: center;
 }
 
 /* 

--- a/starters/nextjs-starter-ts/styles/globals.css
+++ b/starters/nextjs-starter-ts/styles/globals.css
@@ -36,8 +36,8 @@ li::before {
 
 /* Inline images should be horizontally centered. */
 .pantheon-img-container-inline {
-  max-width: 100% !important;
   display: flex;
+  max-width: 100% !important;
   place-items: center;
   flex-direction: column;
 }

--- a/starters/nextjs-starter-ts/styles/globals.css
+++ b/starters/nextjs-starter-ts/styles/globals.css
@@ -22,16 +22,23 @@ li::before {
 }
 
 /* Handle margins and left/right padding for images, to support text wrapping. */
-.prose :where(img):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+.pantheon-img-container img {
   margin: 0;
 }
 
-.prose span[style*="shape-outside"][style*="float:left"] {
+.pantheon-img-container-breakleft {
   padding-right: 2em;
 }
 
-.prose span[style*="shape-outside"][style*="float:right"] {
+.pantheon-img-container-breakright {
   padding-left: 2em;
+}
+
+/* Inline images should be horizontally centered. */
+.pantheon-img-container-inline {
+  max-width: 100% !important;
+  display: flex;
+  justify-content: center;
 }
 
 /* 
@@ -39,7 +46,6 @@ li::before {
   text-wrapped images, but at the cost of not being able
   to set vertical offset of a wrapped image in Google Docs.
 */
-.prose span[style*="shape-outside"] {
+.pantheon-img-container {
   margin: 2em 0;
 }
-

--- a/starters/nextjs-starter-ts/styles/globals.css
+++ b/starters/nextjs-starter-ts/styles/globals.css
@@ -38,9 +38,8 @@ li::before {
 .pantheon-img-container-inline {
   max-width: 100% !important;
   display: flex;
-  justify-items: center;
+  place-items: center;
   flex-direction: column;
-  align-items: center;
 }
 
 /* 

--- a/starters/nextjs-starter/styles/globals.css
+++ b/starters/nextjs-starter/styles/globals.css
@@ -37,9 +37,8 @@ li::before {
 /* Inline images should be horizontally centered. */
 .pantheon-img-container-inline {
   max-width: 100% !important;
-  justify-items: center;
+  place-items: center;
   flex-direction: column;
-  align-items: center;
 }
 
 /* 

--- a/starters/nextjs-starter/styles/globals.css
+++ b/starters/nextjs-starter/styles/globals.css
@@ -37,8 +37,9 @@ li::before {
 /* Inline images should be horizontally centered. */
 .pantheon-img-container-inline {
   max-width: 100% !important;
-  display: flex;
-  justify-content: center;
+  justify-items: center;
+  flex-direction: column;
+  align-items: center;
 }
 
 /* 

--- a/starters/nextjs-starter/styles/globals.css
+++ b/starters/nextjs-starter/styles/globals.css
@@ -13,25 +13,32 @@ li::before {
   }
 
   .responsive-iframe-container {
-    @apply max-w-[640px] relative overflow-hidden pt-[56.25%];
+    @apply relative max-w-[640px] overflow-hidden pt-[56.25%];
   }
 
   .responsive-iframe {
-    @apply absolute top-0 left-0 bottom-0 right-0 w-full h-full;
+    @apply absolute bottom-0 left-0 right-0 top-0 h-full w-full;
   }
 }
 
 /* Handle margins and left/right padding for images, to support text wrapping. */
-.prose :where(img):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+.pantheon-img-container img {
   margin: 0;
 }
 
-.prose span[style*="shape-outside"][style*="float:left"] {
+.pantheon-img-container-breakleft {
   padding-right: 2em;
 }
 
-.prose span[style*="shape-outside"][style*="float:right"] {
+.pantheon-img-container-breakright {
   padding-left: 2em;
+}
+
+/* Inline images should be horizontally centered. */
+.pantheon-img-container-inline {
+  max-width: 100% !important;
+  display: flex;
+  justify-content: center;
 }
 
 /* 
@@ -39,6 +46,6 @@ li::before {
   text-wrapped images, but at the cost of not being able
   to set vertical offset of a wrapped image in Google Docs.
 */
-.prose span[style*="shape-outside"] {
+.pantheon-img-container {
   margin: 2em 0;
 }

--- a/starters/nextjs-starter/styles/globals.css
+++ b/starters/nextjs-starter/styles/globals.css
@@ -20,3 +20,25 @@ li::before {
     @apply absolute top-0 left-0 bottom-0 right-0 w-full h-full;
   }
 }
+
+/* Handle margins and left/right padding for images, to support text wrapping. */
+.prose :where(img):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  margin: 0;
+}
+
+.prose span[style*="shape-outside"][style*="float:left"] {
+  padding-right: 2em;
+}
+
+.prose span[style*="shape-outside"][style*="float:right"] {
+  padding-left: 2em;
+}
+
+/* 
+  This creates consistent spacing above and below
+  text-wrapped images, but at the cost of not being able
+  to set vertical offset of a wrapped image in Google Docs.
+*/
+.prose span[style*="shape-outside"] {
+  margin: 2em 0;
+}

--- a/starters/nextjs-starter/styles/globals.css
+++ b/starters/nextjs-starter/styles/globals.css
@@ -36,6 +36,7 @@ li::before {
 
 /* Inline images should be horizontally centered. */
 .pantheon-img-container-inline {
+  display: flex;
   max-width: 100% !important;
   place-items: center;
   flex-direction: column;


### PR DESCRIPTION
The default CSS results in text-wrapping images having sensible spacing.

Example
![image](https://github.com/user-attachments/assets/8215a84b-ccf6-4457-8c51-763b1fb25726)
