### PR TITLE
[PCC 2172] Return source classes regardless of shouldPruneStyles

### DIFF
--- a/packages/react-sdk/src/components/ArticleRenderer/PantheonTreeV2Renderer.tsx
+++ b/packages/react-sdk/src/components/ArticleRenderer/PantheonTreeV2Renderer.tsx
@@ -141,20 +141,12 @@ const PantheonTreeRenderer = ({
     componentOverride || convertedTagName,
     {
       style: styleObject,
-
-      // If shouldPruneStyles, then overwrite the class
-      // but leave other attrs intact.
-      ...convertAttributes(
-        Object.assign(
-          {},
-          element.attrs,
-          shouldPruneStyles
-            ? { class: targetingClasses.join(" ") }
-            : {
-                class: `${element.attrs.class || ""} ${targetingClasses.join(" ")}`,
-              },
-        ),
-      ),
+      ...convertAttributes({
+        ...element.attrs,
+        class: [element.attrs?.class, ...targetingClasses]
+          .filter(Boolean)
+          .join(" "),
+      }),
     },
     nodeChildren.length ? nodeChildren : undefined,
   );


### PR DESCRIPTION
# Overview
shouldPruneStyles should not be targeting classes as they are not used to define styles by Content Publisher. Classes are currently only used to deliver targeting classes and webstyles