### PR TITLE
Starter kit: Update IMG styles to accomodate newer changes from BE

### DIFF
--- a/packages/react-sdk/src/components/ArticleRenderer/PantheonTreeV2Renderer.tsx
+++ b/packages/react-sdk/src/components/ArticleRenderer/PantheonTreeV2Renderer.tsx
@@ -117,7 +117,7 @@ const PantheonTreeRenderer = ({
       }
     }
 
-    const imageChild = element.children[0];
+    const imageChild = element.children[0].children[0];
     const imageTitle = imageChild.attrs?.title?.trim();
 
     if (renderImageCaptions !== false && imageTitle?.length) {
@@ -155,8 +155,10 @@ const PantheonTreeRenderer = ({
 function isImageContainer(element: PantheonTreeNode<string>) {
   return (
     element.tag === "span" &&
-    element.children?.[0].tag === "img" &&
-    element.children?.length === 1
+    element.children?.[0].tag === "span" &&
+    element.children.length === 1 &&
+    element.children?.[0].children?.[0].tag === "img" &&
+    element.children[0].children?.length === 1
   );
 }
 

--- a/starters/nextjs-starter-approuter-ts/styles/globals.css
+++ b/starters/nextjs-starter-approuter-ts/styles/globals.css
@@ -34,11 +34,11 @@ li::before {
 }
 
 .pantheon-img-container-breakleft {
-  margin-right: 2em;
+  padding-right: 2em;
 }
 
 .pantheon-img-container-breakright {
-  margin-left: 2em;
+  padding-left: 2em;
 }
 
 /* Inline images should be horizontally centered. */

--- a/starters/nextjs-starter-approuter-ts/styles/globals.css
+++ b/starters/nextjs-starter-approuter-ts/styles/globals.css
@@ -26,6 +26,7 @@ li::before {
 /* Handle margins and left/right padding for images, to support text wrapping. */
 .pantheon-img-container img {
   margin: 0;
+  border-radius: 0;
 }
 
 .pantheon-img-container-breakleft {
@@ -52,6 +53,7 @@ li::before {
 */
 .pantheon-img-container {
   margin: 2em 0;
+  border-radius: 1rem;
 }
 
 .pantheon-img-container-inline {

--- a/starters/nextjs-starter-approuter-ts/styles/globals.css
+++ b/starters/nextjs-starter-approuter-ts/styles/globals.css
@@ -24,9 +24,13 @@ li::before {
 }
 
 /* Handle margins and left/right padding for images, to support text wrapping. */
-.pantheon-img-container img {
+.pantheon-img-container span img {
   margin: 0;
   border-radius: 0;
+}
+
+.pantheon-img-container span {
+  border-radius: 1rem;
 }
 
 .pantheon-img-container-breakleft {
@@ -54,7 +58,6 @@ li::before {
 .pantheon-img-container {
   margin-top: 2em;
   margin-bottom: 2em;
-  border-radius: 1rem;
 }
 
 .pantheon-img-container-inline {

--- a/starters/nextjs-starter-approuter-ts/styles/globals.css
+++ b/starters/nextjs-starter-approuter-ts/styles/globals.css
@@ -30,11 +30,11 @@ li::before {
 }
 
 .pantheon-img-container-breakleft {
-  padding-right: 2em;
+  margin-right: 2em;
 }
 
 .pantheon-img-container-breakright {
-  padding-left: 2em;
+  margin-left: 2em;
 }
 
 /* Inline images should be horizontally centered. */
@@ -52,7 +52,8 @@ li::before {
   to set vertical offset of a wrapped image in Google Docs.
 */
 .pantheon-img-container {
-  margin: 2em 0;
+  margin-top: 2em;
+  margin-bottom: 2em;
   border-radius: 1rem;
 }
 

--- a/starters/nextjs-starter-ts/styles/globals.css
+++ b/starters/nextjs-starter-ts/styles/globals.css
@@ -34,11 +34,11 @@ li::before {
 }
 
 .pantheon-img-container-breakleft {
-  margin-right: 2em;
+  padding-right: 2em;
 }
 
 .pantheon-img-container-breakright {
-  margin-left: 2em;
+  padding-left: 2em;
 }
 
 /* Inline images should be horizontally centered. */

--- a/starters/nextjs-starter-ts/styles/globals.css
+++ b/starters/nextjs-starter-ts/styles/globals.css
@@ -26,6 +26,7 @@ li::before {
 /* Handle margins and left/right padding for images, to support text wrapping. */
 .pantheon-img-container img {
   margin: 0;
+  border-radius: 0;
 }
 
 .pantheon-img-container-breakleft {
@@ -52,6 +53,7 @@ li::before {
 */
 .pantheon-img-container {
   margin: 2em 0;
+  border-radius: 1rem;
 }
 
 .pantheon-img-container-inline {

--- a/starters/nextjs-starter-ts/styles/globals.css
+++ b/starters/nextjs-starter-ts/styles/globals.css
@@ -24,9 +24,13 @@ li::before {
 }
 
 /* Handle margins and left/right padding for images, to support text wrapping. */
-.pantheon-img-container img {
+.pantheon-img-container span img {
   margin: 0;
   border-radius: 0;
+}
+
+.pantheon-img-container span {
+  border-radius: 1rem;
 }
 
 .pantheon-img-container-breakleft {
@@ -54,7 +58,6 @@ li::before {
 .pantheon-img-container {
   margin-top: 2em;
   margin-bottom: 2em;
-  border-radius: 1rem;
 }
 
 .pantheon-img-container-inline {

--- a/starters/nextjs-starter-ts/styles/globals.css
+++ b/starters/nextjs-starter-ts/styles/globals.css
@@ -30,11 +30,11 @@ li::before {
 }
 
 .pantheon-img-container-breakleft {
-  padding-right: 2em;
+  margin-right: 2em;
 }
 
 .pantheon-img-container-breakright {
-  padding-left: 2em;
+  margin-left: 2em;
 }
 
 /* Inline images should be horizontally centered. */
@@ -52,7 +52,8 @@ li::before {
   to set vertical offset of a wrapped image in Google Docs.
 */
 .pantheon-img-container {
-  margin: 2em 0;
+  margin-top: 2em;
+  margin-bottom: 2em;
   border-radius: 1rem;
 }
 

--- a/starters/nextjs-starter/styles/globals.css
+++ b/starters/nextjs-starter/styles/globals.css
@@ -34,11 +34,11 @@ li::before {
 }
 
 .pantheon-img-container-breakleft {
-  margin-right: 2em;
+  padding-right: 2em;
 }
 
 .pantheon-img-container-breakright {
-  margin-left: 2em;
+  padding-left: 2em;
 }
 
 /* Inline images should be horizontally centered. */

--- a/starters/nextjs-starter/styles/globals.css
+++ b/starters/nextjs-starter/styles/globals.css
@@ -26,6 +26,7 @@ li::before {
 /* Handle margins and left/right padding for images, to support text wrapping. */
 .pantheon-img-container img {
   margin: 0;
+  border-radius: 0;
 }
 
 .pantheon-img-container-breakleft {
@@ -52,6 +53,7 @@ li::before {
 */
 .pantheon-img-container {
   margin: 2em 0;
+  border-radius: 1rem;
 }
 
 .pantheon-img-container-inline {

--- a/starters/nextjs-starter/styles/globals.css
+++ b/starters/nextjs-starter/styles/globals.css
@@ -24,9 +24,13 @@ li::before {
 }
 
 /* Handle margins and left/right padding for images, to support text wrapping. */
-.pantheon-img-container img {
+.pantheon-img-container span img {
   margin: 0;
   border-radius: 0;
+}
+
+.pantheon-img-container span {
+  border-radius: 1rem;
 }
 
 .pantheon-img-container-breakleft {
@@ -54,7 +58,6 @@ li::before {
 .pantheon-img-container {
   margin-top: 2em;
   margin-bottom: 2em;
-  border-radius: 1rem;
 }
 
 .pantheon-img-container-inline {

--- a/starters/nextjs-starter/styles/globals.css
+++ b/starters/nextjs-starter/styles/globals.css
@@ -30,11 +30,11 @@ li::before {
 }
 
 .pantheon-img-container-breakleft {
-  padding-right: 2em;
+  margin-right: 2em;
 }
 
 .pantheon-img-container-breakright {
-  padding-left: 2em;
+  margin-left: 2em;
 }
 
 /* Inline images should be horizontally centered. */
@@ -52,7 +52,8 @@ li::before {
   to set vertical offset of a wrapped image in Google Docs.
 */
 .pantheon-img-container {
-  margin: 2em 0;
+  margin-top: 2em;
+  margin-bottom: 2em;
   border-radius: 1rem;
 }
 


### PR DESCRIPTION
## Overview
Update styles for images to support newer pattern introduced in BE. [PR](https://github.com/pantheon-systems/pantheon-content-cloud/pull/1035/files)

## Changes:
- Updated PantheonTreeV2 parser to support separate `span` tags for wrapping and cropping styles
- Updated img styles for the same

## Test
[GDoc](https://docs.google.com/document/d/1uzJFslkjlHZEcoQHreWA7KI7_k-iWQzumvnpwtaSWfg/edit?tab=t.0)

Before:
<img width="1726" alt="image" src="https://github.com/user-attachments/assets/999ce42a-990e-4282-ab0f-4d11a1e7e72a" />

After:
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/75c24eaa-86bf-4a04-8a1f-6ff172ac3d7f" />
