### PR TITLE
[PCC 2080] Support querying for related site data in article version

### DIFF
--- a/packages/core/src/helpers/articles.ts
+++ b/packages/core/src/helpers/articles.ts
@@ -5,8 +5,8 @@
 import { ApolloError } from "..";
 import { PantheonClient } from "../core/pantheon-client";
 import {
+  generateArticleQuery,
   generateListArticlesGQL,
-  GET_ARTICLE_QUERY,
   GET_RECOMMENDED_ARTICLES_QUERY,
   LIST_PAGINATED_ARTICLES_QUERY,
   LIST_PAGINATED_ARTICLES_QUERY_W_CONTENT,
@@ -204,6 +204,9 @@ export async function getArticle(
   client: PantheonClient,
   id: number | string,
   args?: ArticleQueryArgs,
+  related?: {
+    site?: boolean;
+  },
 ) {
   const {
     contentType: requestedContentType,
@@ -213,7 +216,7 @@ export async function getArticle(
   const contentType = buildContentType(requestedContentType);
 
   const article = await client.apolloClient.query({
-    query: GET_ARTICLE_QUERY,
+    query: generateArticleQuery({ withSite: related?.site }),
     variables: {
       id: id.toString(),
       contentType,
@@ -231,6 +234,9 @@ export async function getArticleBySlug(
   client: PantheonClient,
   slug: string,
   args?: ArticleQueryArgs,
+  related?: {
+    site?: boolean;
+  },
 ) {
   const {
     contentType: requestedContentType,
@@ -240,7 +246,7 @@ export async function getArticleBySlug(
   const contentType = buildContentType(requestedContentType);
 
   const article = await client.apolloClient.query({
-    query: GET_ARTICLE_QUERY,
+    query: generateArticleQuery({ withSite: related?.site }),
     variables: {
       slug,
       contentType,
@@ -258,11 +264,19 @@ export async function getArticleBySlugOrId(
   client: PantheonClient,
   slugOrId: number | string,
   args?: ArticleQueryArgs,
+  related?: {
+    site?: boolean;
+  },
 ) {
   // First attempt to retrieve by slug, and fallback to by id if the matching slug
   // couldn't be found.
   try {
-    const article = await getArticleBySlug(client, slugOrId.toString(), args);
+    const article = await getArticleBySlug(
+      client,
+      slugOrId.toString(),
+      args,
+      related,
+    );
 
     if (article) {
       return article;
@@ -274,7 +288,7 @@ export async function getArticleBySlugOrId(
   }
 
   try {
-    const article = await getArticle(client, slugOrId, args);
+    const article = await getArticle(client, slugOrId, args, related);
     return article;
   } catch (e) {
     if (

--- a/packages/core/src/helpers/convenience.ts
+++ b/packages/core/src/helpers/convenience.ts
@@ -114,6 +114,7 @@ async function getAllArticlesWithSummary(
 async function getArticleBySlugOrId(
   id: number | string,
   args?: Parameters<typeof _getArticleBySlugOrId>[2],
+  related?: Parameters<typeof _getArticleBySlugOrId>[3],
 ) {
   const post = await _getArticleBySlugOrId(
     buildPantheonClient({ isClientSide: false }),
@@ -123,6 +124,7 @@ async function getArticleBySlugOrId(
       contentType: "TREE_PANTHEON_V2",
       ...args,
     },
+    related,
   );
 
   return post;

--- a/packages/core/src/lib/gql.ts
+++ b/packages/core/src/lib/gql.ts
@@ -1,64 +1,119 @@
 import gql from "graphql-tag";
 
-export const GET_ARTICLE_QUERY = gql`
-  query GetArticle(
-    $id: String
-    $slug: String
-    $contentType: ContentType
-    $publishingLevel: PublishingLevel
-    $versionId: String
-  ) {
-    article(
-      id: $id
-      slug: $slug
-      contentType: $contentType
-      publishingLevel: $publishingLevel
-      versionId: $versionId
-    ) {
-      id
-      title
-      content
-      slug
-      tags
-      siteId
-      metadata
-      publishedDate
-      publishingLevel
-      contentType
-      updatedAt
-      previewActiveUntil
-    }
+const ARTICLE_FIELDS_FRAGMENT = gql`
+  fragment ArticleFields on Article {
+    id
+    title
+    slug
+    tags
+    siteId
+    metadata
+    publishedDate
+    publishingLevel
+    contentType
+    updatedAt
+    previewActiveUntil
   }
 `;
 
-export const ARTICLE_UPDATE_SUBSCRIPTION = gql`
-  subscription OnArticleUpdate(
-    $id: String!
-    $contentType: ContentType
-    $publishingLevel: PublishingLevel
-    $versionId: String
-  ) {
-    article: articleUpdate(
-      id: $id
-      contentType: $contentType
-      publishingLevel: $publishingLevel
-      versionId: $versionId
-    ) {
-      id
-      title
-      siteId
-      content
-      slug
-      tags
-      metadata
-      publishedDate
-      publishingLevel
-      contentType
-      updatedAt
-      previewActiveUntil
-    }
+const SITE_FIELDS_FRAGMENT = gql`
+  fragment SiteFields on Site {
+    id
+    name
+    url
+    domain
+    contentStructure
+    tags
+    metadataFields
   }
 `;
+
+export function generateArticleQuery({
+  withSite = false,
+}: {
+  withSite?: boolean;
+}) {
+  return gql`
+    query GetArticle(
+      $id: String
+      $slug: String
+      $contentType: ContentType
+      $publishingLevel: PublishingLevel
+      $versionId: String
+    ) {
+      article(
+        id: $id
+        slug: $slug
+        contentType: $contentType
+        publishingLevel: $publishingLevel
+        versionId: $versionId
+      ) {
+        ...ArticleFields
+        content
+        ${
+          withSite
+            ? `
+        site {
+          ...SiteFields
+        }`
+            : ""
+        }
+      }
+    }
+    ${ARTICLE_FIELDS_FRAGMENT}
+    ${withSite ? SITE_FIELDS_FRAGMENT : ""}
+  `;
+}
+
+export const GET_ARTICLE_QUERY = generateArticleQuery({ withSite: false });
+
+export const GET_ARTICLE_WITH_SITE_QUERY = generateArticleQuery({
+  withSite: true,
+});
+
+export function generateArticleUpdateSubscription({
+  withSite = false,
+}: {
+  withSite?: boolean;
+}) {
+  return gql`
+    subscription OnArticleUpdate(
+      $id: String!
+      $contentType: ContentType
+      $publishingLevel: PublishingLevel
+      $versionId: String
+    ) {
+      article: articleUpdate(
+        id: $id
+        contentType: $contentType
+        publishingLevel: $publishingLevel
+        versionId: $versionId
+      ) {
+        ...ArticleFields
+        content
+        ${
+          withSite
+            ? `
+        site {
+          ...SiteFields
+        }`
+            : ""
+        }
+      }
+    }
+    ${ARTICLE_FIELDS_FRAGMENT}
+    ${withSite ? SITE_FIELDS_FRAGMENT : ""}
+  `;
+}
+
+export const ARTICLE_UPDATE_SUBSCRIPTION = generateArticleUpdateSubscription({
+  withSite: false,
+});
+
+export const ARTICLE_UPDATE_SUBSCRIPTION_WITH_SITE =
+  generateArticleUpdateSubscription({
+    withSite: true,
+  });
 
 export function generateListArticlesGQL({
   withContent = false,
@@ -130,119 +185,68 @@ export const LIST_ARTICLES_QUERY_WITH_CONTENT_AND_SUMMARY =
     withSummary: true,
   });
 
-export const LIST_PAGINATED_ARTICLES_QUERY = gql`
-  query ListArticles(
-    $pageSize: Int
-    $sortBy: ArticleSortField
-    $sortOrder: SortOrder
-    $cursor: String
-    $contentType: ContentType
-    $publishingLevel: PublishingLevel
-    $filter: ArticleFilterInput
-    $metadataFilters: String
-  ) {
-    articlesv3(
-      pageSize: $pageSize
-      sortBy: $sortBy
-      sortOrder: $sortOrder
-      cursor: $cursor
-      contentType: $contentType
-      publishingLevel: $publishingLevel
-      filter: $filter
-      metadataFilters: $metadataFilters
+export function generateListPaginatedArticlesGQL({
+  withContent = false,
+}: {
+  withContent?: boolean;
+}) {
+  return gql`
+    query ListArticles(
+      $pageSize: Int
+      $sortBy: ArticleSortField
+      $sortOrder: SortOrder
+      $cursor: String
+      $contentType: ContentType
+      $publishingLevel: PublishingLevel
+      $filter: ArticleFilterInput
+      $metadataFilters: String
     ) {
-      articles {
-        id
-        title
-        siteId
-        slug
-        tags
-        metadata
-        publishedDate
-        publishingLevel
-        contentType
-        updatedAt
-        previewActiveUntil
-      }
-      pageInfo {
-        totalCount
-        nextCursor
+      articlesv3(
+        pageSize: $pageSize
+        sortBy: $sortBy
+        sortOrder: $sortOrder
+        cursor: $cursor
+        contentType: $contentType
+        publishingLevel: $publishingLevel
+        filter: $filter
+        metadataFilters: $metadataFilters
+      ) {
+        articles {
+          ...ArticleFields
+          ${withContent ? "content" : ""}
+        }
+        pageInfo {
+          totalCount
+          nextCursor
+        }
       }
     }
-  }
-`;
+    ${ARTICLE_FIELDS_FRAGMENT}
+  `;
+}
 
-export const LIST_PAGINATED_ARTICLES_QUERY_W_CONTENT = gql`
-  query ListArticles(
-    $pageSize: Int
-    $sortBy: ArticleSortField
-    $sortOrder: SortOrder
-    $cursor: String
-    $contentType: ContentType
-    $publishingLevel: PublishingLevel
-    $filter: ArticleFilterInput
-    $metadataFilters: String
-  ) {
-    articlesv3(
-      pageSize: $pageSize
-      sortBy: $sortBy
-      sortOrder: $sortOrder
-      cursor: $cursor
-      contentType: $contentType
-      publishingLevel: $publishingLevel
-      filter: $filter
-      metadataFilters: $metadataFilters
-    ) {
-      articles {
-        id
-        title
-        siteId
-        tags
-        metadata
-        publishedDate
-        publishingLevel
-        contentType
-        content
-        updatedAt
-        previewActiveUntil
-      }
-      pageInfo {
-        totalCount
-        nextCursor
-      }
-    }
-  }
-`;
+export const LIST_PAGINATED_ARTICLES_QUERY = generateListPaginatedArticlesGQL({
+  withContent: false,
+});
+
+export const LIST_PAGINATED_ARTICLES_QUERY_W_CONTENT =
+  generateListPaginatedArticlesGQL({ withContent: true });
 
 export const GET_RECOMMENDED_ARTICLES_QUERY = gql`
   query GetRecommendedArticle($id: String!) {
     recommendedArticles(id: $id) {
-      id
-      title
+      ...ArticleFields
       content
-      slug
-      tags
-      siteId
-      metadata
-      publishedDate
-      publishingLevel
-      contentType
-      updatedAt
-      previewActiveUntil
     }
   }
+  ${ARTICLE_FIELDS_FRAGMENT}
 `;
 
 export const GET_SITE_QUERY = gql`
   query GetSite($id: String!) {
     site(id: $id) {
-      id
-      name
-      url
-      domain
-      contentStructure
-      tags
-      metadataFields
+      ...SiteFields
     }
   }
+  ${SITE_FIELDS_FRAGMENT}
 `;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -13,6 +13,7 @@ export interface Article {
   metadata: Record<string, unknown> | null;
   previewActiveUntil: number | null;
   snippet?: string | null;
+  site?: Site | null;
 }
 
 export type ArticleSummaryResponse = {

--- a/packages/react-sdk/src/hooks/use-article.ts
+++ b/packages/react-sdk/src/hooks/use-article.ts
@@ -4,7 +4,7 @@ import {
   ARTICLE_UPDATE_SUBSCRIPTION,
   ArticleQueryArgs,
   buildContentType,
-  GET_ARTICLE_QUERY,
+  generateArticleQuery,
 } from "@pantheon-systems/pcc-sdk-core";
 import { Article } from "@pantheon-systems/pcc-sdk-core/types";
 import { useEffect, useMemo } from "react";
@@ -22,6 +22,9 @@ export const useArticle = (
   id: string,
   args?: ArticleQueryArgs,
   apolloQueryOptions?: ApolloQueryOptions,
+  related?: {
+    site?: boolean;
+  },
 ): Return => {
   const publishingLevel = args?.publishingLevel;
   const contentType = buildContentType(args?.contentType);
@@ -34,7 +37,7 @@ export const useArticle = (
   }, [publishingLevel, contentType]);
 
   const { subscribeToMore, ...queryData } = useQuery<{ article: Article }>(
-    GET_ARTICLE_QUERY,
+    generateArticleQuery({ withSite: related?.site }),
     {
       ...apolloQueryOptions,
       variables: { id, ...memoizedArgs },

--- a/starters/nextjs-starter-ts/pages/articles/[...uri].tsx
+++ b/starters/nextjs-starter-ts/pages/articles/[...uri].tsx
@@ -68,7 +68,7 @@ export async function getServerSideProps({
   };
 }) {
   const slugOrId = uri[uri.length - 1];
-  const grant = pccGrant || cookies["PCC-GRANT"] || null;
+  const grant = pccGrant || cookies["PCC-GRANT"];
 
   // Fetch the article and the site in parallel
   const [article, site] = await Promise.all([
@@ -122,8 +122,8 @@ export async function getServerSideProps({
   return {
     props: {
       article,
-      grant,
-      publishingLevel,
+      grant: grant || null,
+      publishingLevel: publishingLevel || null,
       versionId: versionId || null,
       recommendedArticles: await PCCConvenienceFunctions.getRecommendedArticles(
         article.id,

--- a/starters/nextjs-starter/pages/articles/[...uri].jsx
+++ b/starters/nextjs-starter/pages/articles/[...uri].jsx
@@ -102,8 +102,8 @@ export async function getServerSideProps({
   return {
     props: {
       article,
-      grant,
-      publishingLevel,
+      grant: grant || null,
+      publishingLevel: publishingLevel || null,
       versionId: versionId || null,
       recommendedArticles: await PCCConvenienceFunctions.getRecommendedArticles(
         article.id,


### PR DESCRIPTION
# Overview
Updates GraphQL query definitions in SDK to match new serverside query definitions, adding support for querying related site data in an article version

# Other changes
- Fixed undefined value serialisation errors in starters
- Update GraphQL query definitions to use [fragments](https://www.npmjs.com/package/graphql-tag#fragments), reducing code duplication