### PR TITLE
Allow cdnURLOverride to be a url rewrite function

### DIFF
--- a/.changeset/lazy-jeans-learn.md
+++ b/.changeset/lazy-jeans-learn.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/pcc-react-sdk": patch
+---
+
+cdnURLOverride now allows you to provide a function to rewrite the url.

--- a/packages/react-sdk/__tests__/components/ArticleRenderer.test.tsx
+++ b/packages/react-sdk/__tests__/components/ArticleRenderer.test.tsx
@@ -50,4 +50,61 @@ describe("<ArticleRenderer />", () => {
     );
     expect(tree).toMatchSnapshot();
   });
+
+  it("should replace the CDN URL with the override (markdown with function)", () => {
+    const tree = renderer
+      .create(
+        <ArticleRenderer
+          article={articleWithImageMarkdown as Article}
+          __experimentalFlags={{
+            cdnURLOverride: (url) =>
+              url.replace(
+                /cdn\.staging\.content.pantheon.io\/[^/]+/,
+                "cdn.example.com",
+              ),
+          }}
+        />,
+      )
+      .toJSON();
+
+    expect(
+      JSON.stringify(tree).includes(
+        "https://cdn.example.com/djHVTYbPaCby44H5CxhH",
+      ),
+    ).toBe(true);
+    expect(
+      JSON.stringify(tree).includes(
+        "https://cdn.staging.content.pantheon.io/loAWY0YB0HTHexSzw3Z1/djHVTYbPaCby44H5CxhH",
+      ),
+    ).toBe(false);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("should replace the CDN URL with the override (tree with function)", () => {
+    const tree = renderer
+      .create(
+        <ArticleRenderer
+          article={articleWithImageTree as Article}
+          __experimentalFlags={{
+            cdnURLOverride: (url) =>
+              url.replace(
+                /cdn\.staging\.content.pantheon.io\/[^/]+/,
+                "cdn.example.com",
+              ),
+          }}
+        />,
+      )
+      .toJSON();
+    expect(
+      JSON.stringify(tree).includes(
+        "https://cdn.example.com/djHVTYbPaCby44H5CxhH",
+      ),
+    ).toBe(true);
+    expect(
+      JSON.stringify(tree).includes(
+        "https://cdn.staging.content.pantheon.io/loAWY0YB0HTHexSzw3Z1/djHVTYbPaCby44H5CxhH",
+      ),
+    ).toBe(false);
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/react-sdk/__tests__/components/__snapshots__/ArticleRenderer.test.tsx.snap
+++ b/packages/react-sdk/__tests__/components/__snapshots__/ArticleRenderer.test.tsx.snap
@@ -628,6 +628,94 @@ exports[`<ArticleRenderer /> should render a post's content 1`] = `
 </div>
 `;
 
+exports[`<ArticleRenderer /> should replace the CDN URL with the override (markdown with function) 1`] = `
+<div>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque vitae leo nec massa semper venenatis eu at felis. Nam consequat accumsan dictum. Suspendisse eu metus in justo eleifend consequat id quis nunc. Etiam pharetra, tortor id malesuada efficitur, ligula sem posuere erat, vitae placerat ipsum felis non leo. Praesent lobortis, mauris vel posuere bibendum, leo diam vehicula lacus, a interdum odio massa et elit. Suspendisse ac lorem imperdiet, suscipit quam eu, maximus elit. Quisque nec metus eu nibh iaculis dignissim. Cras ultricies pulvinar erat eget luctus. In id ipsum non diam sagittis ullamcorper eget nec arcu. Ut laoreet accumsan ex non porta. Donec vitae mi porttitor, dictum lacus sit amet, dapibus ipsum. Praesent bibendum lacus nibh, sed egestas enim facilisis vitae!
+    <img
+      alt=""
+      src="https://cdn.example.com/djHVTYbPaCby44H5CxhH"
+      title="just another dog"
+    />
+  </p>
+  
+
+  <p>
+    Integer pretium bibendum ipsum, vehicula placerat orci finibus id. Proin orci mauris, ornare commodo congue sit amet, dignissim non eros. Nullam risus nibh, dictum et enim vel, vestibulum maximus velit. Proin eu porta risus. Aliquam nec lacus et lacus commodo elementum. Mauris quis massa ac urna iaculis hendrerit. Nulla eget ullamcorper lorem, in rutrum sapien. Vivamus finibus placerat massa a mollis.
+  </p>
+  
+
+  <p>
+    Cras vitae ultricies odio. Vestibulum iaculis interdum feugiat. Donec iaculis finibus lorem. Quisque lacinia volutpat magna, in dapibus lectus gravida id. Cras iaculis justo et diam elementum, nec rhoncus dolor efficitur. Sed lacus libero, lobortis in mauris ut, imperdiet suscipit quam. Sed eu leo vitae sapien vestibulum viverra.
+  </p>
+  
+
+  <p>
+    Morbi varius, velit volutpat auctor malesuada, nisi mi rhoncus urna, at tempus risus libero ac turpis. Nullam sit amet porta leo. Nam dapibus maximus ante, vitae fringilla ipsum lacinia posuere. Donec efficitur, odio ac blandit convallis, purus arcu posuere risus, maximus scelerisque quam augue id ante. Etiam ultrices neque in purus rhoncus laoreet. Nunc bibendum tincidunt felis, quis molestie libero dictum scelerisque. Sed urna dolor, elementum eget auctor tincidunt, lacinia in diam. Duis a libero tristique, luctus lacus aliquet, fermentum odio. Integer lacinia nunc metus, ac egestas nibh mattis a. Fusce sodales mollis odio non pulvinar. Nulla vitae dignissim nibh, ac finibus neque.
+  </p>
+  
+
+  <p>
+    Mauris mollis, lacus eu sodales tincidunt, ipsum ex pharetra libero, eu posuere ante lectus nec velit. Sed commodo ultrices diam eget pulvinar. Vestibulum volutpat sapien non nisl porttitor, sed euismod magna sollicitudin. Suspendisse potenti. Sed posuere sapien id magna euismod tincidunt. Phasellus in cursus diam, eget vestibulum ipsum. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Curabitur tempus mollis tempus. Phasellus rhoncus, turpis sed mollis rutrum, tellus mauris hendrerit nulla, a congue dolor mauris in leo. Sed feugiat posuere neque, eget cursus est luctus at. Vestibulum accumsan convallis ante in auctor. Aliquam ac orci sem. Nunc auctor mauris sed felis tristique, nec malesuada ante porta.
+  </p>
+  
+
+  <p>
+    Sed et ligula nec nisl convallis volutpat. Curabitur semper massa ac mollis feugiat. Vestibulum eget orci ac arcu tempus dapibus. Nunc augue lorem, ultrices in velit non, porta cursus ex. Aenean eget nunc sit amet quam vulputate porttitor vitae sed ex. Morbi porttitor libero nec hendrerit vehicula. Ut maximus odio ac odio blandit pharetra. Etiam quis condimentum est. Morbi dui nisi, ornare at dignissim vel, ultrices rhoncus nisl. Sed at euismod enim. Quisque efficitur orci a velit pretium scelerisque. Nulla eleifend feugiat porta. Etiam eu rhoncus lectus.
+    <img
+      alt=""
+      src="https://cdn.example.com/ZWJn6ilXOYs9oS9iDgMH"
+      title="This is a title"
+    />
+  </p>
+  
+
+  <p>
+    THIS PUPPY BREAKS UP TEXT Etiam maximus mauris eu felis interdum, in bibendum orci sodales. In posuere elit quam. Nulla dictum, sapien ut sagittis consequat, nisl elit suscipit lectus, a blandit risus nunc eget nunc. Donec augue ante, eleifend non risus at, dignissim gravida ipsum. Vivamus tristique tempor dui, at condimentum dui tristique nec. Suspendisse potenti. Nulla facilisi. Quisque orci risus, iaculis vel vehicula eu, cursus sit amet justo. Cras sed erat a est tristique elementum.
+  </p>
+  
+
+  <p>
+    Morbi justo lorem, ultricies ut volutpat aliquam, blandit eu erat. Duis accumsan egestas convallis. Morbi a finibus lectus. Vivamus vel ultrices felis. Donec faucibus placerat mi, non pellentesque est lacinia non. Ut vitae metus leo. Mauris volutpat malesuada lorem, et auctor metus sodales ultrices. Nulla rhoncus augue pulvinar consectetur bibendum. Nunc ac urna vel mauris venenatis euismod in et massa.
+  </p>
+  
+
+  <p>
+    Proin sed laoreet augue. Aliquam malesuada vel ex ut vestibulum. Mauris at libero vestibulum, vehicula mi nec, ullamcorper magna. Vivamus bibendum ipsum imperdiet placerat pharetra. Curabitur fermentum id est a tristique. Integer at semper erat. Phasellus volutpat dolor in ipsum hendrerit, eu maximus libero mattis. Nunc aliquam, tortor at congue vehicula, mi purus mollis metus, et convallis orci quam at elit.
+    <img
+      alt=""
+      src="https://cdn.example.com/RoJOqZdOWPaxWCVnH9sD"
+    />
+  </p>
+  
+
+  <p>
+    Etiam non eleifend nisl. Morbi eu libero a erat volutpat dictum eu sodales urna. Ut venenatis rutrum dolor, a euismod nibh egestas a. Nullam pretium congue tellus, eu tempor est consectetur et. Etiam dapibus consequat volutpat. Nunc sed bibendum ipsum, a egestas risus. Nulla id dolor nibh. Nulla tempor diam eget sapien elementum faucibus. Sed elementum, mi ut maximus facilisis, ex enim fringilla sem, at fermentum odio mi id diam. Pellentesque vitae commodo felis. Vestibulum eget diam pellentesque, porttitor ante a, ultricies lacus.
+    <img
+      alt=""
+      src="https://cdn.example.com/RoJOqZdOWPaxWCVnH9sD"
+    />
+  </p>
+  
+
+  <p>
+    <img
+      alt=""
+      src="https://cdn.example.com/RoJOqZdOWPaxWCVnH9sD"
+    />
+  </p>
+  
+
+  <p>
+    <img
+      alt=""
+      src="https://cdn.example.com/RoJOqZdOWPaxWCVnH9sD"
+      title="inline puppies"
+    />
+  </p>
+</div>
+`;
+
 exports[`<ArticleRenderer /> should replace the CDN URL with the override (markdown) 1`] = `
 <div>
   <p>
@@ -713,6 +801,473 @@ exports[`<ArticleRenderer /> should replace the CDN URL with the override (markd
       title="inline puppies"
     />
   </p>
+</div>
+`;
+
+exports[`<ArticleRenderer /> should replace the CDN URL with the override (tree with function) 1`] = `
+<div>
+  <div>
+    <p
+      className="normal-text"
+      style={
+        {
+          "margin": "0",
+          "marginBottom": "11PT",
+        }
+      }
+    >
+      <span
+        className=""
+      >
+        <span
+          className=""
+        >
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque vitae leo nec massa semper venenatis eu at felis. Nam consequat accumsan dictum. Suspendisse eu metus in justo eleifend consequat id quis nunc. Etiam pharetra, tortor id malesuada efficitur, ligula sem posuere erat, vitae placerat ipsum felis non leo. Praesent lobortis, mauris vel posuere bibendum, leo diam vehicula lacus, a interdum odio massa et elit. Suspendisse ac lorem imperdiet, suscipit quam eu, maximus elit. Quisque nec metus eu nibh iaculis dignissim. Cras ultricies pulvinar erat eget luctus. In id ipsum non diam sagittis ullamcorper eget nec arcu. Ut laoreet accumsan ex non porta. Donec vitae mi porttitor, dictum lacus sit amet, dapibus ipsum. Praesent bibendum lacus nibh, sed egestas enim facilisis vitae!
+        </span>
+      </span>
+      <span
+        className="pantheon-img-container pantheon-img-container-breakright"
+        style={
+          {
+            "float": "right",
+            "height": "auto",
+            "marginTop": "170.85929748535153px",
+            "maxHeight": "352.00px",
+            "maxWidth": "480.00px",
+            "shapeOutside": "padding-box",
+            "width": "100%",
+          }
+        }
+      >
+        <img
+          className=""
+          src="https://cdn.example.com/djHVTYbPaCby44H5CxhH"
+          style={
+            {
+              "height": "auto",
+              "marginLeft": "0.00px",
+              "maxHeight": "352.00px",
+              "maxWidth": "480.00px",
+              "width": "100%",
+            }
+          }
+          title="just another dog"
+        />
+        <span
+          className="pantheon-caption"
+          style={
+            {
+              "display": "flex",
+              "fontSize": ".75rem",
+              "justifyContent": "center",
+              "width": "100%",
+            }
+          }
+        >
+          just another dog
+        </span>
+      </span>
+    </p>
+  </div>
+  <div>
+    <style
+      dangerouslySetInnerHTML={
+        {
+          "__html": "
+
+ul.nesting-level-1 {
+  list-style-type: disc; 
+}
+ul.nesting-level-2 {
+  list-style-type: circle; 
+}
+ul.nesting-level-3 {
+  list-style-type: square; 
+}
+ul.nesting-level-4 {
+  list-style-type: disc; 
+}
+ul.nesting-level-5 {
+  list-style-type: circle; 
+}
+ul.nesting-level-6 {
+  list-style-type: square; 
+}
+ul.nesting-level-7 {
+  list-style-type: disc; 
+}
+ul.nesting-level-8 {
+  list-style-type: circle; 
+}
+
+
+ol[list-style-type="decimal"] {
+  list-style-type: decimal;
+}
+ol[list-style-type="lower-alpha"] {
+  list-style-type: lower-alpha;
+}
+ol[list-style-type="lower-roman"] { 
+  list-style-type: lower-roman;
+}
+
+",
+        }
+      }
+    />
+    <p
+      className="normal-text"
+      style={
+        {
+          "margin": "0",
+          "marginBottom": "11PT",
+        }
+      }
+    >
+      <span
+        className=""
+      >
+        <span
+          className=""
+        >
+          Integer pretium bibendum ipsum, vehicula placerat orci finibus id. Proin orci mauris, ornare commodo congue sit amet, dignissim non eros. Nullam risus nibh, dictum et enim vel, vestibulum maximus velit. Proin eu porta risus. Aliquam nec lacus et lacus commodo elementum. Mauris quis massa ac urna iaculis hendrerit. Nulla eget ullamcorper lorem, in rutrum sapien. Vivamus finibus placerat massa a mollis.
+        </span>
+      </span>
+    </p>
+    <p
+      className="normal-text"
+      style={
+        {
+          "margin": "0",
+          "marginBottom": "11PT",
+        }
+      }
+    >
+      <span
+        className=""
+      >
+        <span
+          className=""
+        >
+          Cras vitae ultricies odio. Vestibulum iaculis interdum feugiat. Donec iaculis finibus lorem. Quisque lacinia volutpat magna, in dapibus lectus gravida id. Cras iaculis justo et diam elementum, nec rhoncus dolor efficitur. Sed lacus libero, lobortis in mauris ut, imperdiet suscipit quam. Sed eu leo vitae sapien vestibulum viverra.
+        </span>
+      </span>
+    </p>
+    <p
+      className="normal-text"
+      style={
+        {
+          "margin": "0",
+          "marginBottom": "11PT",
+        }
+      }
+    >
+      <span
+        className=""
+      >
+        <span
+          className=""
+        >
+          Morbi varius, velit volutpat auctor malesuada, nisi mi rhoncus urna, at tempus risus libero ac turpis. Nullam sit amet porta leo. Nam dapibus maximus ante, vitae fringilla ipsum lacinia posuere. Donec efficitur, odio ac blandit convallis, purus arcu posuere risus, maximus scelerisque quam augue id ante. Etiam ultrices neque in purus rhoncus laoreet. Nunc bibendum tincidunt felis, quis molestie libero dictum scelerisque. Sed urna dolor, elementum eget auctor tincidunt, lacinia in diam. Duis a libero tristique, luctus lacus aliquet, fermentum odio. Integer lacinia nunc metus, ac egestas nibh mattis a. Fusce sodales mollis odio non pulvinar. Nulla vitae dignissim nibh, ac finibus neque.
+        </span>
+      </span>
+    </p>
+    <p
+      className="normal-text"
+      style={
+        {
+          "margin": "0",
+          "marginBottom": "11PT",
+        }
+      }
+    >
+      <span
+        className=""
+      >
+        <span
+          className=""
+        >
+          Mauris mollis, lacus eu sodales tincidunt, ipsum ex pharetra libero, eu posuere ante lectus nec velit. Sed commodo ultrices diam eget pulvinar. Vestibulum volutpat sapien non nisl porttitor, sed euismod magna sollicitudin. Suspendisse potenti. Sed posuere sapien id magna euismod tincidunt. Phasellus in cursus diam, eget vestibulum ipsum. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Curabitur tempus mollis tempus. Phasellus rhoncus, turpis sed mollis rutrum, tellus mauris hendrerit nulla, a congue dolor mauris in leo. Sed feugiat posuere neque, eget cursus est luctus at. Vestibulum accumsan convallis ante in auctor. Aliquam ac orci sem. Nunc auctor mauris sed felis tristique, nec malesuada ante porta.
+        </span>
+      </span>
+    </p>
+    <p
+      className="normal-text"
+      style={
+        {
+          "margin": "0",
+          "marginBottom": "11PT",
+        }
+      }
+    >
+      <span
+        className=""
+      >
+        <span
+          className=""
+        >
+          Sed et ligula nec nisl convallis volutpat. Curabitur semper massa ac mollis feugiat. Vestibulum eget orci ac arcu tempus dapibus. Nunc augue lorem, ultrices in velit non, porta cursus ex. Aenean eget nunc sit amet quam vulputate porttitor vitae sed ex. Morbi porttitor libero nec hendrerit vehicula. Ut maximus odio ac odio blandit pharetra. Etiam quis condimentum est. Morbi dui nisi, ornare at dignissim vel, ultrices rhoncus nisl. Sed at euismod enim. Quisque efficitur orci a velit pretium scelerisque. Nulla eleifend feugiat porta. Etiam eu rhoncus lectus.
+        </span>
+      </span>
+      <span
+        className="pantheon-img-container pantheon-img-container-breakleft"
+        style={
+          {
+            "float": "left",
+            "height": "auto",
+            "marginTop": "24.937500000000085px",
+            "maxHeight": "350.00px",
+            "maxWidth": "470.00px",
+            "shapeOutside": "padding-box",
+            "width": "100%",
+          }
+        }
+      >
+        <img
+          className=""
+          src="https://cdn.example.com/ZWJn6ilXOYs9oS9iDgMH"
+          style={
+            {
+              "height": "auto",
+              "marginLeft": "0.00px",
+              "maxHeight": "350.00px",
+              "maxWidth": "470.00px",
+              "width": "100%",
+            }
+          }
+          title="This is a title"
+        />
+        <span
+          className="pantheon-caption"
+          style={
+            {
+              "display": "flex",
+              "fontSize": ".75rem",
+              "justifyContent": "center",
+              "width": "100%",
+            }
+          }
+        >
+          This is a title
+        </span>
+      </span>
+    </p>
+    <p
+      className="normal-text"
+      style={
+        {
+          "margin": "0",
+          "marginBottom": "11PT",
+        }
+      }
+    >
+      <span
+        className=""
+      >
+        <span
+          className=""
+        >
+          THIS PUPPY BREAKS UP TEXT Etiam maximus mauris eu felis interdum, in bibendum orci sodales. In posuere elit quam. Nulla dictum, sapien ut sagittis consequat, nisl elit suscipit lectus, a blandit risus nunc eget nunc. Donec augue ante, eleifend non risus at, dignissim gravida ipsum. Vivamus tristique tempor dui, at condimentum dui tristique nec. Suspendisse potenti. Nulla facilisi. Quisque orci risus, iaculis vel vehicula eu, cursus sit amet justo. Cras sed erat a est tristique elementum.
+        </span>
+      </span>
+    </p>
+    <p
+      className="normal-text"
+      style={
+        {
+          "margin": "0",
+          "marginBottom": "11PT",
+        }
+      }
+    >
+      <span
+        className=""
+      >
+        <span
+          className=""
+        >
+          Morbi justo lorem, ultricies ut volutpat aliquam, blandit eu erat. Duis accumsan egestas convallis. Morbi a finibus lectus. Vivamus vel ultrices felis. Donec faucibus placerat mi, non pellentesque est lacinia non. Ut vitae metus leo. Mauris volutpat malesuada lorem, et auctor metus sodales ultrices. Nulla rhoncus augue pulvinar consectetur bibendum. Nunc ac urna vel mauris venenatis euismod in et massa.
+        </span>
+      </span>
+    </p>
+    <p
+      className="normal-text"
+      style={
+        {
+          "margin": "0",
+          "marginBottom": "11PT",
+        }
+      }
+    >
+      <span
+        className=""
+      >
+        <span
+          className=""
+        >
+          Proin sed laoreet augue. Aliquam malesuada vel ex ut vestibulum. Mauris at libero vestibulum, vehicula mi nec, ullamcorper magna. Vivamus bibendum ipsum imperdiet placerat pharetra. Curabitur fermentum id est a tristique. Integer at semper erat. Phasellus volutpat dolor in ipsum hendrerit, eu maximus libero mattis. Nunc aliquam, tortor at congue vehicula, mi purus mollis metus, et convallis orci quam at elit.
+        </span>
+      </span>
+      <span
+        className="pantheon-img-container pantheon-img-container-breakright"
+        style={
+          {
+            "float": "right",
+            "height": "auto",
+            "marginTop": "64.63423339843754px",
+            "maxHeight": "352.00px",
+            "maxWidth": "462.00px",
+            "shapeOutside": "padding-box",
+            "width": "100%",
+          }
+        }
+      >
+        <img
+          className=""
+          src="https://cdn.example.com/RoJOqZdOWPaxWCVnH9sD"
+          style={
+            {
+              "height": "auto",
+              "marginLeft": "0.00px",
+              "maxHeight": "352.00px",
+              "maxWidth": "462.00px",
+              "width": "100%",
+            }
+          }
+        />
+      </span>
+    </p>
+    <p
+      className="normal-text"
+      style={
+        {
+          "margin": "0",
+          "marginBottom": "11PT",
+        }
+      }
+    >
+      <span
+        className=""
+      >
+        <span
+          className=""
+        >
+          Etiam non eleifend nisl. Morbi eu libero a erat volutpat dictum eu sodales urna. Ut venenatis rutrum dolor, a euismod nibh egestas a. Nullam pretium congue tellus, eu tempor est consectetur et. Etiam dapibus consequat volutpat. Nunc sed bibendum ipsum, a egestas risus. Nulla id dolor nibh. Nulla tempor diam eget sapien elementum faucibus. Sed elementum, mi ut maximus facilisis, ex enim fringilla sem, at fermentum odio mi id diam. Pellentesque vitae commodo felis. Vestibulum eget diam pellentesque, porttitor ante a, ultricies lacus.
+        </span>
+      </span>
+      <span
+        className="pantheon-img-container pantheon-img-container-inline pantheon-img-container-alone"
+        style={
+          {
+            "border": "0.00px solid #000000",
+            "display": "inline-block",
+            "height": "auto",
+            "margin": "0.00px 0.00px",
+            "maxHeight": "193.99px",
+            "maxWidth": "256.50px",
+            "overflow": "hidden",
+            "width": "100%",
+          }
+        }
+      >
+        <img
+          className=""
+          src="https://cdn.example.com/RoJOqZdOWPaxWCVnH9sD"
+          style={
+            {
+              "height": "auto",
+              "marginLeft": "0.00px",
+              "maxHeight": "193.99px",
+              "maxWidth": "256.50px",
+              "width": "100%",
+            }
+          }
+        />
+      </span>
+    </p>
+    <p
+      className="normal-text"
+      style={
+        {
+          "margin": "0",
+        }
+      }
+    >
+      <span
+        className="pantheon-img-container pantheon-img-container-inline pantheon-img-container-alone"
+        style={
+          {
+            "height": "auto",
+            "maxHeight": "90.22325805664047px",
+            "maxWidth": "118.41802619934062px",
+            "width": "100%",
+          }
+        }
+      >
+        <img
+          className=""
+          src="https://cdn.example.com/RoJOqZdOWPaxWCVnH9sD"
+          style={
+            {
+              "height": "auto",
+              "marginLeft": "0.00px",
+              "maxHeight": "90.45px",
+              "maxWidth": "118.71px",
+              "width": "100%",
+            }
+          }
+        />
+      </span>
+    </p>
+    <p
+      className="normal-text"
+      style={
+        {
+          "margin": "0",
+        }
+      }
+    >
+      <span
+        className="pantheon-img-container pantheon-img-container-inline pantheon-img-container-alone"
+        style={
+          {
+            "height": "auto",
+            "maxHeight": "57.30575805664048px",
+            "maxWidth": "75.77094676378019px",
+            "width": "100%",
+          }
+        }
+      >
+        <img
+          className=""
+          src="https://cdn.example.com/RoJOqZdOWPaxWCVnH9sD"
+          style={
+            {
+              "height": "auto",
+              "marginLeft": "0.00px",
+              "maxHeight": "57.45px",
+              "maxWidth": "75.96px",
+              "width": "100%",
+            }
+          }
+          title="inline puppies"
+        />
+        <span
+          className="pantheon-caption"
+          style={
+            {
+              "display": "flex",
+              "fontSize": ".75rem",
+              "justifyContent": "center",
+              "width": "100%",
+            }
+          }
+        >
+          inline puppies
+        </span>
+      </span>
+    </p>
+  </div>
 </div>
 `;
 

--- a/packages/react-sdk/src/components/ArticleRenderer/Markdown.tsx
+++ b/packages/react-sdk/src/components/ArticleRenderer/Markdown.tsx
@@ -14,7 +14,7 @@ interface MarkdownRendererProps {
   smartComponentMap?: SmartComponentMap;
   componentMap?: ComponentMap;
   disableDefaultErrorBoundaries: boolean;
-  cdnURLOverride?: string;
+  cdnURLOverride?: string | ((url: string) => string);
 }
 
 interface ComponentProperties {
@@ -126,7 +126,7 @@ function fixComponentParentRehypePlugin() {
 /**
  * Rehype plugin to override the CDN domain.
  */
-function overrideCDNUrls(cdnURLOverride?: string) {
+function overrideCDNUrls(cdnURLOverride?: string | ((url: string) => string)) {
   // If cdnURLOverride is not provided, return a no-op transformer:
   if (!cdnURLOverride) {
     return () => (tree: UnistParent) => tree;
@@ -143,8 +143,12 @@ function overrideCDNUrls(cdnURLOverride?: string) {
             const url = new URL(src);
 
             if (CDNDomains.includes(url.hostname)) {
-              url.hostname = cdnURLOverride;
-              node.properties.src = url.toString();
+              if (typeof cdnURLOverride === "function") {
+                node.properties.src = cdnURLOverride(url.toString());
+              } else {
+                url.hostname = cdnURLOverride;
+                node.properties.src = url.toString();
+              }
             }
           }
         } catch (err) {

--- a/packages/react-sdk/src/components/ArticleRenderer/PantheonTreeV2Renderer.tsx
+++ b/packages/react-sdk/src/components/ArticleRenderer/PantheonTreeV2Renderer.tsx
@@ -14,7 +14,7 @@ interface Props {
   preserveImageStyles?: boolean;
   disableDefaultErrorBoundaries?: boolean;
   renderImageCaptions?: boolean;
-  cdnURLOverride?: string;
+  cdnURLOverride?: string | ((url: string) => string);
 }
 
 const PantheonTreeRenderer = ({
@@ -131,8 +131,12 @@ const PantheonTreeRenderer = ({
         const srcUrl = new URL(imageChild.attrs.src);
 
         if (CDNDomains.includes(srcUrl.hostname)) {
-          srcUrl.hostname = cdnURLOverride;
-          imageChild.attrs.src = srcUrl.toString();
+          if (typeof cdnURLOverride === "function") {
+            imageChild.attrs.src = cdnURLOverride(srcUrl.toString());
+          } else {
+            srcUrl.hostname = cdnURLOverride;
+            imageChild.attrs.src = srcUrl.toString();
+          }
         }
       } catch (err) {
         // If it's not a valid URL (or cannot be parsed), leave it unchanged.

--- a/packages/react-sdk/src/components/ArticleRenderer/index.tsx
+++ b/packages/react-sdk/src/components/ArticleRenderer/index.tsx
@@ -58,7 +58,7 @@ interface Props {
     disableDefaultErrorBoundaries?: boolean;
     useUnintrusiveTitleRendering?: boolean;
     renderImageCaptions?: boolean;
-    cdnURLOverride?: string;
+    cdnURLOverride?: string | ((url: string) => string);
   };
 }
 

--- a/starters/nextjs-starter-approuter-ts/components/article-view.tsx
+++ b/starters/nextjs-starter-approuter-ts/components/article-view.tsx
@@ -123,7 +123,6 @@ export function StaticArticleView({
           disableAllStyles: !!onlyContent,
           preserveImageStyles: true,
           useUnintrusiveTitleRendering: true,
-          cdnURLOverride: (url) => url.replace(/cdn\.staging\.content\.pantheon\.io\/[^/]+/, "cdn.example.com"),
         }}
       />
 

--- a/starters/nextjs-starter-approuter-ts/components/article-view.tsx
+++ b/starters/nextjs-starter-approuter-ts/components/article-view.tsx
@@ -123,22 +123,23 @@ export function StaticArticleView({
           disableAllStyles: !!onlyContent,
           preserveImageStyles: true,
           useUnintrusiveTitleRendering: true,
+          cdnURLOverride: (url) => url.replace(/cdn\.staging\.content\.pantheon\.io\/[^/]+/, "cdn.example.com"),
         }}
       />
 
       <div className="border-base-300 mt-16 flex w-full flex-wrap gap-x-3 gap-y-3 border-t-[1px] pt-9 lg:mt-32">
         {seoMetadata.keywords != null
           ? (Array.isArray(seoMetadata.keywords)
-              ? seoMetadata.keywords
-              : [seoMetadata.keywords]
-            ).map((x, i) => (
-              <div
-                key={i}
-                className="text-bold text-neutral-content inline-block rounded-full border border-[#D4D4D4] bg-[#F5F5F5] px-3 py-1 text-sm !no-underline"
-              >
-                {x}
-              </div>
-            ))
+            ? seoMetadata.keywords
+            : [seoMetadata.keywords]
+          ).map((x, i) => (
+            <div
+              key={i}
+              className="text-bold text-neutral-content inline-block rounded-full border border-[#D4D4D4] bg-[#F5F5F5] px-3 py-1 text-sm !no-underline"
+            >
+              {x}
+            </div>
+          ))
           : null}
       </div>
     </div>


### PR DESCRIPTION
Example usage
`cdnURLOverride: (url) => url.replace(/cdn\.prod\.pcc\.pantheon\.io\/[^/]+/, "agcdn-protected.pantheon.io/cdn"),`