### PR TITLE
Fix silent catch blocks, remove unused mocks, clean up type casts

### DIFF
--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -66,7 +66,8 @@ export class Auth0Provider extends BaseAuthProvider {
       );
       await LocalStorage.persistAuthDetails(newCred);
       return newCred;
-    } catch {
+    } catch (e) {
+      console.error(e);
       return null;
     }
   }

--- a/starters/nextjs-starter-approuter-ts/__mocks__/next/image.jsx
+++ b/starters/nextjs-starter-approuter-ts/__mocks__/next/image.jsx
@@ -1,5 +1,0 @@
-// Mock the next/image component because it relies on next.config.js
-export default function (props) {
-	const { src, alt, width } = props;
-	return <img src={src} alt={alt} width={width} />;
-}

--- a/starters/nextjs-starter-approuter-ts/components/grid.tsx
+++ b/starters/nextjs-starter-approuter-ts/components/grid.tsx
@@ -82,8 +82,8 @@ function withImageSizeParams(
     u.searchParams.set("width", width.toString());
     u.searchParams.set("height", height.toString());
     return u.toString();
-  } catch {
-    // If url is not valid, return as is
+  } catch (e) {
+    console.error(e);
     return url;
   }
 }

--- a/starters/nextjs-starter-approuter-ts/lib/utils.ts
+++ b/starters/nextjs-starter-approuter-ts/lib/utils.ts
@@ -109,7 +109,8 @@ export function parseAsTabTree(
     return JSON.parse(raw) as TabTree<
       PantheonTree | string | undefined | null
     >[];
-  } catch {
+  } catch (e) {
+    console.error(e);
     return null;
   }
 }

--- a/starters/nextjs-starter-ts/__mocks__/next/image.jsx
+++ b/starters/nextjs-starter-ts/__mocks__/next/image.jsx
@@ -1,5 +1,0 @@
-// Mock the next/image component because it relies on next.config.js
-export default function (props) {
-	const { src, alt, width } = props;
-	return <img src={src} alt={alt} width={width} />;
-}

--- a/starters/nextjs-starter-ts/components/grid.tsx
+++ b/starters/nextjs-starter-ts/components/grid.tsx
@@ -80,8 +80,8 @@ function withImageSizeParams(
     u.searchParams.set("width", width.toString());
     u.searchParams.set("height", height.toString());
     return u.toString();
-  } catch {
-    // If url is not valid, return as is
+  } catch (e) {
+    console.error(e);
     return url;
   }
 }

--- a/starters/nextjs-starter-ts/components/smart-components/error-boundary.tsx
+++ b/starters/nextjs-starter-ts/components/smart-components/error-boundary.tsx
@@ -35,12 +35,11 @@ const SmartComponentSuspenseErrorBoundary = ({ children }: Props) => {
 };
 
 export const withSmartComponentErrorBoundary =
-  <T extends Record<string, unknown>>(
-    Component: React.ComponentType<T>,
-  ): ((props: unknown) => React.JSX.Element) =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (Component: React.ComponentType<any>): ((props: unknown) => React.JSX.Element) =>
   (props: unknown) => (
     <SmartComponentSuspenseErrorBoundary>
-      <Component {...(props as T)} />
+      <Component {...(props as Record<string, unknown>)} />
     </SmartComponentSuspenseErrorBoundary>
   );
 

--- a/starters/nextjs-starter-ts/components/smart-components/index.ts
+++ b/starters/nextjs-starter-ts/components/smart-components/index.ts
@@ -67,20 +67,14 @@ export const serverSmartComponentMap = {
 export const clientSmartComponentMap: SmartComponentMap = {
   MEDIA_PREVIEW: {
     ...serverSmartComponentMap.MEDIA_PREVIEW,
-    reactComponent: withSmartComponentErrorBoundary(
-      MediaPreview as unknown as React.ComponentType<Record<string, unknown>>,
-    ) as (props: unknown) => React.JSX.Element,
+    reactComponent: withSmartComponentErrorBoundary(MediaPreview),
   },
   LEAD_CAPTURE: {
     ...serverSmartComponentMap.LEAD_CAPTURE,
-    reactComponent: withSmartComponentErrorBoundary(
-      LeadCapture as unknown as React.ComponentType<Record<string, unknown>>,
-    ) as (props: unknown) => React.JSX.Element,
+    reactComponent: withSmartComponentErrorBoundary(LeadCapture),
   },
   TILE_NAVIGATION: {
     ...serverSmartComponentMap.TILE_NAVIGATION,
-    reactComponent: withSmartComponentErrorBoundary(
-      TileNavigation as unknown as React.ComponentType<Record<string, unknown>>,
-    ) as (props: unknown) => React.JSX.Element,
+    reactComponent: withSmartComponentErrorBoundary(TileNavigation),
   },
 };

--- a/starters/nextjs-starter-ts/lib/utils.ts
+++ b/starters/nextjs-starter-ts/lib/utils.ts
@@ -117,7 +117,8 @@ export function parseAsTabTree(
     return JSON.parse(raw) as TabTree<
       PantheonTree | string | undefined | null
     >[];
-  } catch {
+  } catch (e) {
+    console.error(e);
     return null;
   }
 }

--- a/starters/nextjs-starter-ts/pages/api/utils/paginate.ts
+++ b/starters/nextjs-starter-ts/pages/api/utils/paginate.ts
@@ -12,7 +12,8 @@ export default async function handler(
   let pageSize: number;
   try {
     pageSize = parseInt(req.query.pageSize as string);
-  } catch {
+  } catch (e) {
+    console.error(e);
     return res.status(400).json("Invalid pageSize");
   }
 

--- a/starters/nextjs-starter/__mocks__/next/image.jsx
+++ b/starters/nextjs-starter/__mocks__/next/image.jsx
@@ -1,5 +1,0 @@
-// Mock the next/image component because it relies on next.config.js
-export default function (props) {
-	const { src, alt, width } = props;
-	return <img src={src} alt={alt} width={width} />;
-}

--- a/starters/nextjs-starter/components/grid.jsx
+++ b/starters/nextjs-starter/components/grid.jsx
@@ -50,8 +50,8 @@ function withImageSizeParams(url, width = 400, height = 400) {
     u.searchParams.set("width", width.toString());
     u.searchParams.set("height", height.toString());
     return u.toString();
-  } catch {
-    // If url is not valid, return as is
+  } catch (e) {
+    console.error(e);
     return url;
   }
 }

--- a/starters/nextjs-starter/lib/utils.js
+++ b/starters/nextjs-starter/lib/utils.js
@@ -91,7 +91,8 @@ export function parseAsTabTree(raw) {
 
   try {
     return JSON.parse(raw);
-  } catch {
+  } catch (e) {
+    console.error(e);
     return null;
   }
 }

--- a/starters/nextjs-starter/pages/api/utils/paginate.js
+++ b/starters/nextjs-starter/pages/api/utils/paginate.js
@@ -8,7 +8,8 @@ export default async function handler(req, res) {
   let pageSize;
   try {
     pageSize = parseInt(req.query.pageSize);
-  } catch {
+  } catch (e) {
+    console.error(e);
     return res.status(400).json("Invalid pageSize");
   }
 


### PR DESCRIPTION
## Summary

- **Log errors in silent catch blocks**: Added `console.error(e)` to catch blocks that previously swallowed errors silently across all 3 Next.js starters and the CLI:
  - `withImageSizeParams()` in `grid.tsx`/`grid.jsx` (all starters)
  - `parseAsTabTree()` in `utils.ts`/`utils.js` (all starters)
  - `getTokens()` refresh failure in `auth.ts` (CLI)
  - `paginate` API route `parseInt` failure in `paginate.ts`/`paginate.js` (pages-router starters)

- **Remove unused `__mocks__` directories**: Deleted `__mocks__/next/image.jsx` from all 3 starters. No test files exist in the starters, so these mocks are completely unused. They were being shipped to end users via `pcc init` since `downloadTemplateDirectory` only filters out `turbo.json`.

- **Simplify smart component type casts**: In `nextjs-starter-ts`, replaced the triple `as unknown as React.ComponentType<Record<string, unknown>>` double-cast pattern with a cleaner approach: widened `withSmartComponentErrorBoundary` to accept `React.ComponentType<any>` (the generic constraint was not enforcing safety since the function already casts props internally). This matches the pattern used in the approuter starter's `client-components.ts`.

## Test plan

- [ ] Verify starters build successfully in CI
- [ ] Confirm `pcc init` no longer scaffolds `__mocks__` directories
- [ ] Verify smart component error boundaries still render correctly in nextjs-starter-ts